### PR TITLE
Provide options for rotating log files in a specified directory and to output console debug to log file

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,20 +13,6 @@ var path = require('path');
 var fs = require('fs');
 require('stream');
 
-// TEMPORARY...
-Date.prototype.toJSON = function()
-{
-  return (
-    this.getUTCFullYear() + "-" +
-    ("0" + (this.getUTCMonth() + 1)).substr(-2) + "-" +
-    ("0" + this.getUTCDate()).substr(-2) + "T" +
-    ("0" + this.getUTCHours()).substr(-2) + ":" +
-    ("0" + this.getUTCMinutes()).substr(-2) + ":" +
-    ("0" + this.getUTCSeconds()).substr(-2) + "." +
-    ("00" + this.getUTCMilliseconds()).substr(-3));
-};
-// ...TEMPORARY
-
 
 /*!
  * Default log buffer duration.


### PR DESCRIPTION
This patch adds the following options:
- logdir: The directory in which rotating log files shall be placed
- retaindays: The number of days log files should be retained before being automatically removed
- redirect_console:  Which console debugging functions (log, debug, warn, error) should be redirected to the logging stream

This patch is backward compatible, by simply omitting the new options.
