### PR TITLE
Docs in readme, cleaned code comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,75 @@
-# Connect Logger
+# Morgan [![Build Status](https://travis-ci.org/expressjs/morgan.svg)](https://travis-ci.org/expressjs/morgan) [![NPM version](https://badge.fury.io/js/morgan.svg)](http://badge.fury.io/js/morgan)
 
-Connect's logging middleware. Named after [Dexter](http://en.wikipedia.org/wiki/Dexter_Morgan), a show you should not watch until completion. You may view the old docs at http://www.senchalabs.org/connect/logger.html. Otherwise, view the source code's JSDocs.
+Logging middleware for node.js http apps.
+
+> Named after [Dexter](http://en.wikipedia.org/wiki/Dexter_Morgan), a show you should not watch until completion.
+
+## API
+
+```js
+var express = require('express')
+  , morgan  = require('morgan')
+  , app     = express()
+
+app.use(morgan())
+```
+
+### morgan(options)
+
+Morgan may be passed options to configure the logging output. The options may be passed as a predefined format, formatting string, function, or object.
+
+```js
+morgan() // default
+morgan('short')
+morgan('tiny')
+morgan({ format: 'dev', immediate: true })
+morgan(':method :url - :referrer')
+morgan(':req[content-type] -> :res[content-type]')
+morgan(function(tokens, req, res){ return 'some format string' })
+morgan({ format: 'dev', skip: function(req, res){ return res.statusCode === 304; }})
+```
+
+#### Predefined Formats
+
+- `default` - Standard output.
+- `short` - Shorter than default, also including response time.
+- `tiny` - The minimal.
+- `dev` - Concise output colored by response status for development use.
+
+#### Options
+
+Morgan accepts these properties in the options object.
+
+- `format` - Format string or Setting, see below for format tokens.
+- `stream` - Output stream, defaults to `stdout`.
+- `buffer` - Buffer duration, defaults to `1000 ms` when `true`.
+- `immediate` - Write log line on request instead of response (for response times).
+- `skip` - Function to determine if logging is skipped, called as `skip(req, res)`, defaults to `false`.
+
+All default formats are defined this way, however the api is also public:
+```js
+morgan.format('name', 'string or function')
+```
+
+#### Tokens
+
+- `:req[header]` ex: `:req[Accept]`
+- `:res[header]` ex: `:res[Content-Length]`
+- `:http-version`
+- `:response-time`
+- `:remote-addr`
+- `:date`
+- `:method`
+- `:url`
+- `:referrer`
+- `:user-agent`
+- `:status`
+
+To define a token, simply invoke `morgan.token()` with the name and a callback function. The value returned is then available as ":type" in this case:
+```js
+morgan.token('type', function(req, res){ return req.headers['content-type']; })
+```
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*!
- * Connect - logger
+ * Morgan | Connect - logger
  * Copyright(c) 2010 Sencha Inc.
  * Copyright(c) 2011 TJ Holowaychuk
  * MIT Licensed
@@ -18,69 +18,12 @@ var bytes = require('bytes');
 var defaultBufferDuration = 1000;
 
 /**
- * Logger:
- *
  * Log requests with the given `options` or a `format` string.
  *
- * Options:
- *
- *   - `format`  Format string, see below for tokens
- *   - `stream`  Output stream, defaults to _stdout_
- *   - `buffer`  Buffer duration, defaults to 1000ms when _true_
- *   - `immediate`  Write log line on request instead of response (for response times)
- *   - `skip`    Function to determine if logging is skipped, called as
- *               `skip(req, res)`, defaults to always false.
- *
- * Tokens:
- *
- *   - `:req[header]` ex: `:req[Accept]`
- *   - `:res[header]` ex: `:res[Content-Length]`
- *   - `:http-version`
- *   - `:response-time`
- *   - `:remote-addr`
- *   - `:date`
- *   - `:method`
- *   - `:url`
- *   - `:referrer`
- *   - `:user-agent`
- *   - `:status`
- *
- * Formats:
- *
- *   Pre-defined formats that ship with connect:
- *
- *    - `default` ':remote-addr - - [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"'
- *    - `short` ':remote-addr - :method :url HTTP/:http-version :status :res[content-length] - :response-time ms'
- *    - `tiny`  ':method :url :status :res[content-length] - :response-time ms'
- *    - `dev` concise output colored by response status for development use
- *
- * Examples:
- *
- *      connect.logger() // default
- *      connect.logger('short')
- *      connect.logger('tiny')
- *      connect.logger({ immediate: true, format: 'dev' })
- *      connect.logger(':method :url - :referrer')
- *      connect.logger(':req[content-type] -> :res[content-type]')
- *      connect.logger(function(tokens, req, res){ return 'some format string' })
- *      connect.logger({ format: 'dev', skip: function(req, res){ return res.statusCode === 304; }})
- *
- * Defining Tokens:
- *
- *   To define a token, simply invoke `connect.logger.token()` with the
- *   name and a callback function. The value returned is then available
- *   as ":type" in this case.
- *
- *      connect.logger.token('type', function(req, res){ return req.headers['content-type']; })
- *
- * Defining Formats:
- *
- *   All default formats are defined this way, however it's public API as well:
- *
- *       connect.logger.format('name', 'string or function')
+ * See README.md for documentation of options and formatting.
  *
  * @param {String|Function|Object} format or options
- * @return {Function}
+ * @return {Function} middleware
  * @api public
  */
 
@@ -201,8 +144,8 @@ exports.token = function(name, fn) {
  * @api public
  */
 
-exports.format = function(name, str){
-  exports[name] = str;
+exports.format = function(name, fmt){
+  exports[name] = fmt;
   return this;
 };
 


### PR DESCRIPTION
Add build and npm module badges.
Keep function params same as jsdocs.

Just to keep track of code comments. If I do anything like this in the future I'll just do it in PR form because it is far more sane.

EDIT: eff. I screwed this up pretty bad.

See: 12b8d58 & 4b85f3e
