### PR TITLE
(1.2.0) add dev+ format

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,23 @@ exports.format('dev', function(tokens, req, res){
 });
 
 /**
+ * dev+ (dev with more information)
+ */
+
+exports.format('dev+', function(tokens, req, res){
+  var color = 32; // green
+  var status = res.statusCode;
+
+  if (status >= 500) color = 31; // red
+  else if (status >= 400) color = 33; // yellow
+  else if (status >= 300) color = 36; // cyan
+
+  var fn = compile('\x1b[90m:remote-addr \x1b[32m:method \x1b[35m:url \x1b[/' + color + 'm:status \x1b[97m:response-time ms\x1b[0m');
+
+  return fn(tokens, req, res);
+});
+
+/**
  * request url
  */
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "morgan",
   "description": "http request logger middleware for node.js",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Jonathan Ong",
     "email": "me@jongleberry.com",


### PR DESCRIPTION
Added dev+ logging format (dev with more information)

I used dev for easy logging in my server. I decided it needed to give IP addresses, etc.
Please add this as an optional way to get more information during development.
Will not be useful to everyone, but it definitely can't hurt.
