### PR TITLE
Change color used for standard output text.

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ exports.format('dev', function(tokens, req, res){
   else if (status >= 400) color = 33; // yellow
   else if (status >= 300) color = 36; // cyan
 
-  var fn = compile('\x1b[90m:method :url \x1b[' + color + 'm:status \x1b[90m:response-time ms - :res[content-length]\x1b[0m');
+  var fn = compile('\x1b[0m:method :url \x1b[' + color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m');
 
   return fn(tokens, req, res);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -284,7 +284,7 @@ describe('logger()', function () {
         .end(function (err, res) {
           if (err) return done(err)
           lastLogLine = lastLogLine.replace(/\x1b\[(\d+)m/g, '_color_$1_')
-          lastLogLine.should.startWith('_color_90_GET / _color_32_200 _color_90_')
+          lastLogLine.should.startWith('_color_0_GET / _color_32_200 _color_0_')
           lastLogLine.should.endWith('_color_0_\n')
           done()
         })
@@ -300,7 +300,7 @@ describe('logger()', function () {
         .end(function (err, res) {
           if (err) return done(err)
           lastLogLine = lastLogLine.replace(/\x1b\[(\d+)m/g, '_color_$1_')
-          lastLogLine.should.startWith('_color_90_GET / _color_31_500 _color_90_')
+          lastLogLine.should.startWith('_color_0_GET / _color_31_500 _color_0_')
           lastLogLine.should.endWith('_color_0_\n')
           done()
         })
@@ -316,7 +316,7 @@ describe('logger()', function () {
         .end(function (err, res) {
           if (err) return done(err)
           lastLogLine = lastLogLine.replace(/\x1b\[(\d+)m/g, '_color_$1_')
-          lastLogLine.should.startWith('_color_90_GET / _color_33_400 _color_90_')
+          lastLogLine.should.startWith('_color_0_GET / _color_33_400 _color_0_')
           lastLogLine.should.endWith('_color_0_\n')
           done()
         })
@@ -332,7 +332,7 @@ describe('logger()', function () {
         .end(function (err, res) {
           if (err) return done(err)
           lastLogLine = lastLogLine.replace(/\x1b\[(\d+)m/g, '_color_$1_')
-          lastLogLine.should.startWith('_color_90_GET / _color_36_300 _color_90_')
+          lastLogLine.should.startWith('_color_0_GET / _color_36_300 _color_0_')
           lastLogLine.should.endWith('_color_0_\n')
           done()
         })


### PR DESCRIPTION
This alleviates an invisible text problem in some themes.

Many themes have trouble with the Grey ANSI color 90 that is being used in dev output.

I'm seeing this in Solarized Dark, but it is a problem in other themes as well.

Changing from 1b[90m to 1b[92m fixed the problem for me.

Last year Bower made a similar change for the same reason.
