### PR TITLE
Added x-forwarded-for to :remote-addr token

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,6 +264,7 @@ exports.token('referrer', function(req){
  */
 
 exports.token('remote-addr', function(req){
+  if (req.header('x-forwarded-for')) return req.header('x-forwarded-for');
   if (req.ip) return req.ip;
   if (req._remoteAddress) return req._remoteAddress;
   if (req.connection) return req.connection.remoteAddress;


### PR DESCRIPTION
(Issue #2)

Is there a reason this wasn't implemented?

If there are security concerns, perhaps this could be added as a separate token (`:forwarded-for-addr`?)
