### PR TITLE
fix wrong parameter list in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ morgan('combined')
 morgan(':remote-addr :method :url')
 
 // a custom function
-morgan(function (req, res) {
+morgan(function (morgan, req, res) {
   return req.method + ' ' + req.url
 })
 ```


### PR DESCRIPTION
Got choked up on this because the README had `req` as the first parameter accepted by the custom function, but in fact the first parameter is the `morgan` object itself.
