### PR TITLE
Update index.js get ip has a little wrong where web proxy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,9 +383,9 @@ function clfdate(dateTime) {
 function getip(req) {
   return (req.headers['x-forwarded-for']
     || req._remoteAddress
-    || req.connection.remoteAddress
-    || req.socket.remoteAddress
-    || req.connection.socket.remoteAddress
+    || (req.connection && req.connection.remoteAddress)
+    || (req.socket && req.socket.remoteAddress)
+    || (req.connection && req.connection.socket && req.connection.socket.remoteAddress)
   ).split(',')[0];
 }
 


### PR DESCRIPTION
Fixed getip function. 
When nginx proxy to Node.js http.

<pre>
location /api_v1/ {
   proxy_pass http://127.0.0.1:8000/;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
}
</pre>


Other way for the question.
Function getip allow redefined by user.
