### PR TITLE
Adding method to get formatted string inside format function. Closes #61

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,42 @@ function assignId(req, res, next) {
   next()
 }
 ```
+### using a function as a format.
+Sending log data to a separate logger. 
+
+```javascript 
+var express = require('express')
+var morgan = require('morgan')
+var logger = require('myCustomLogger')
+var app = express()
+
+
+app.use(morgan(function(tokens, req, res){
+
+	// Extract your data from the request.
+	var reqData = {
+     "remote-addr": tokens['remote-addr'](req, res),
+     "date": tokens['date'](req, res),
+     "method": tokens['method'](req, res),
+     "status": tokens['status'](req, res),
+     "response-time": tokens['response-time'](req, res)
+	}
+	
+	// tokens.getFormatted returns a formatted string.
+	var formatLine = tokens.getFormatted(req, res, 'common')
+	
+	logger.log(formatLine, reqData)
+	
+	//or do something with your data and return the formatted string.
+	logger.writeData(reqData)
+	return formatLine
+	
+	//or do something async and write your formatted line manually.
+	logger.writeAsyncData(reqData, function(err){
+		console.log(formatLine)
+	})
+});
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -200,15 +200,11 @@ exports.format = function(name, fmt){
  * @param {string} format
  * @returns {string}
  */
+
 exports.getFormatted = function(req, res, format) {
-  if(!req['headers']){
-    deprecate('getFormatted expects a req and request object as parameters.')
-    return ''
-  }
   var fmt = (exports[format] || format || exports.default)
   var formatted = compile(fmt);
   return formatted(exports, req, res)
-
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -193,6 +193,25 @@ exports.format = function(name, fmt){
 };
 
 /**
+ * Returns formatted string. Useful when using a function as a format.
+ *
+ * @param {object} req
+ * @param {object} res
+ * @param {string} format
+ * @returns {string}
+ */
+exports.getFormatted = function(req, res, format) {
+  if(!req['headers']){
+    deprecate('getFormatted expects a req and request object as parameters.')
+    return ''
+  }
+  var fmt = (exports[format] || format || exports.default)
+  var formatted = compile(fmt);
+  return formatted(exports, req, res)
+
+}
+
+/**
  * Apache combined log format.
  */
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -632,21 +632,6 @@ describe('morgan()', function () {
             done()
           })
       })
-
-      it('should return empty string if req.headers not present', function(done) {
-        var line
-        var server = createServer(function(tokens, req, res){
-          line = tokens.getFormatted({}, res);
-        })
-
-        request(server)
-          .get('/')
-          .end(function (err, res) {
-            if (err) return done(err)
-            assert.equal(line, '')
-            done()
-          })
-      })
     })
   })
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -596,6 +596,58 @@ describe('morgan()', function () {
         })
       })
     })
+
+    describe('function()', function(){
+      it('getFormat should return a formatted string', function(done) {
+        var line
+        var server = createServer(function(tokens, req, res){
+          line = tokens.getFormatted(req, res, 'common');
+        })
+
+        request(server)
+          .get('/')
+          .end(function (err, res) {
+            if (err) return done(err)
+            line = line.replace(/\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000/, '_timestamp_')
+            assert.equal(line, res.text + ' - - [_timestamp_] "GET / HTTP/1.1" 200 -')
+            done()
+          })
+      })
+
+      it('should return default format if none specified', function(done) {
+        var line
+        var server = createServer(function(tokens, req, res){
+          line = tokens.getFormatted(req, res);
+        })
+
+        request(server)
+          .get('/')
+          .set('Authorization', 'Basic dGo6')
+          .set('Referer', 'http://localhost/')
+          .set('User-Agent', 'my-ua')
+          .end(function (err, res) {
+            if (err) return done(err)
+            line = line.replace(/\w+, \d+ \w+ \d+ \d+:\d+:\d+ \w+/, '_timestamp_')
+            assert.equal(line, res.text + ' - tj [_timestamp_] "GET / HTTP/1.1" 200 - "http://localhost/" "my-ua"')
+            done()
+          })
+      })
+
+      it('should return empty string if req.headers not present', function(done) {
+        var line
+        var server = createServer(function(tokens, req, res){
+          line = tokens.getFormatted({}, res);
+        })
+
+        request(server)
+          .get('/')
+          .end(function (err, res) {
+            if (err) return done(err)
+            assert.equal(line, '')
+            done()
+          })
+      })
+    })
   })
 
   describe('with buffer option', function () {


### PR DESCRIPTION
This is a fairly simple method that uses the existing compile function to return a formatted string. I also added 3 tests, and added a section to the docs detailing the "function as format" option.

This closes issue #61 