### PR TITLE
Write stream includeTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ morgan('combined', {
 
 Output stream for writing log lines, defaults to `process.stdout`.
 
-If the stream object has an `includeTokens` property set to `true`, the processed tokens from the format string will be available as the second argument to the write callback. This is useful for passing tokens as metadata to winston or another logger.
+##### logger
+
+Pass the formatted log line and the processed token/value pairs to a function. This can
+then be passed on to winston or another logger.
 
 #### Predefined Formats
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ morgan('combined', {
 
 Output stream for writing log lines, defaults to `process.stdout`.
 
+If the stream object has an `includeTokens` property set to `true`, the processed tokens from the format string will be available as the second argument to the write callback. This is useful for passing tokens as metadata to winston or another logger.
+
 #### Predefined Formats
 
 There are various pre-defined formats provided:

--- a/index.js
+++ b/index.js
@@ -70,8 +70,9 @@ exports = module.exports = function morgan(format, options) {
   // steam
   var buffer = options.buffer
   var stream = options.stream || process.stdout
-  var includeTokens = options.stream ? options.stream.includeTokens === true : false
-
+  // logger
+  var logger = options.logger
+  
   // buffering support
   if (buffer) {
     deprecate('buffer option')
@@ -105,7 +106,7 @@ exports = module.exports = function morgan(format, options) {
     };
   }
 
-  return function logger(req, res, next) {
+  return function(req, res, next) {
     req._startAt = process.hrtime();
     req._startTime = new Date;
     req._remoteAddress = getip(req);
@@ -122,7 +123,7 @@ exports = module.exports = function morgan(format, options) {
       
       if (typeof formatted === 'object') {
         line = formatted.line;
-        tokenPairs = formatted.tokenPairs
+        tokenPairs = formatted.tokenPairs;
       } else {
         line = formatted;
       }
@@ -133,7 +134,11 @@ exports = module.exports = function morgan(format, options) {
       }
 
       debug('log request');
-      includeTokens ? stream.write(line + '\n', tokenPairs) : stream.write(line + '\n');
+      if (logger) {
+        logger(line, tokenPairs);
+      } else {
+        stream.write(line + '\n');
+      }
     };
 
     // immediate

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -703,34 +703,14 @@ describe('morgan()', function () {
     })
   })
   
-  describe('with stream option', function () {
-    it('should callback to write with line', function (done) {
+  describe('with logger option', function () {
+    it('should callback with line and token pairs', function (done) {
       var server = createServer(':method :url', {
-        stream: {write: writeLog}
+        logger: writeLog
       })
 
       function writeLog(log, tokens) {
-        assert.equal(log, 'GET /first\n')
-        assert.equal(tokens, undefined)
-        server.close()
-        done()
-      }
-
-      server = server.listen()
-      request(server)
-      .get('/first')
-      .end(function (err, res) {
-        if (err) throw err
-      })
-    })
-    
-    it('should callback to write with line and token pairs', function (done) {
-      var server = createServer(':method :url', {
-        stream: {includeTokens: true, write: writeLog}
-      })
-
-      function writeLog(log, tokens) {
-        assert.equal(log, 'GET /first\n')
+        assert.equal(log, 'GET /first')
         assert.deepEqual(tokens, {method: 'GET', url: '/first'})
         server.close()
         done()

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -702,6 +702,49 @@ describe('morgan()', function () {
       })
     })
   })
+  
+  describe('with stream option', function () {
+    it('should callback to write with line', function (done) {
+      var server = createServer(':method :url', {
+        stream: {write: writeLog}
+      })
+
+      function writeLog(log, tokens) {
+        assert.equal(log, 'GET /first\n')
+        assert.equal(tokens, undefined)
+        server.close()
+        done()
+      }
+
+      server = server.listen()
+      request(server)
+      .get('/first')
+      .end(function (err, res) {
+        if (err) throw err
+      })
+    })
+    
+    it('should callback to write with line and token pairs', function (done) {
+      var server = createServer(':method :url', {
+        stream: {includeTokens: true, write: writeLog}
+      })
+
+      function writeLog(log, tokens) {
+        assert.equal(log, 'GET /first\n')
+        assert.deepEqual(tokens, {method: 'GET', url: '/first'})
+        server.close()
+        done()
+      }
+
+      server = server.listen()
+      request(server)
+      .get('/first')
+      .end(function (err, res) {
+        if (err) throw err
+      })
+    })
+  })
+  
 })
 
 function createLogger(format, opts) {


### PR DESCRIPTION
We had a need to access processed tokens inside the stream write callback. We pass the tokens to winston as metadata and didn't want to double process the tokens.

This change modifies the compile function to return the formatted string and the tokens.

FWIW I think we've been working towards the same thing as #62. We didn't see that PR when we started work on this and we've taken a different approach that avoids calling the token functions twice.

One potential downside (or maybe upside) to this approach is that your tokens need to be in the format string for them to be available in the write callback.

```javascript
morgan('common', {
  stream: {
    includeTokens: true,
    write: function(line, metadata) {
      logger.info(line, metadata);
    }
  }
})
```
