### PR TITLE
Update to log response time once res triggered event 'finish'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 node_modules/
 npm-debug.log
+/.project

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ function morgan(format, options) {
 
       // log when response finished
       res.on('finish', logRequest)
+      res.on('close', logRequest)
     }
 
     next();

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function morgan(format, options) {
       onHeaders(res, recordStartTime)
 
       // log when response finished
-      onFinished(res, logRequest)
+      res.on('finish', logRequest)
     }
 
     next();


### PR DESCRIPTION
Both nodejs 0.12 and sailsjs moc-res support res.on 'finish'. To log response time for sailsjs web socket request, it is suggested to log response time by listening to response event 'finish' instead of checking response property finished or complete. Please review.