### PR TITLE
Using npm module remote-ip to get remote ip address

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var debug = require('debug')('morgan')
 var deprecate = require('depd')('morgan')
 var onFinished = require('on-finished')
 var onHeaders = require('on-headers')
+var requestIp = require('request-ip')
 
 /**
  * Array of CLF month names.
@@ -455,10 +456,7 @@ function getFormatFunction(name) {
  */
 
 function getip(req) {
-  return req.ip
-    || req._remoteAddress
-    || (req.connection && req.connection.remoteAddress)
-    || undefined;
+  return requestIp.getClientIp(req)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "debug": "~2.2.0",
     "depd": "~1.1.0",
     "on-finished": "~2.3.0",
-    "on-headers": "~1.0.1"
+    "on-headers": "~1.0.1",
+    "request-ip": "^1.1.4"
   },
   "devDependencies": {
     "istanbul": "0.4.0",


### PR DESCRIPTION
The remote address will not be displayed correctly if e.g. the application is behind Nginx. Using NPM module "remote-ip" is a much more reliable solution IMHO.