### PR TITLE
kayvee request logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "basic-auth": "~1.0.3",
     "debug": "~2.2.0",
     "depd": "~1.1.0",
+    "node-uuid": "^1.4.7",
     "on-finished": "~2.3.0",
     "on-headers": "~1.0.1"
   },
   "devDependencies": {
+    "express": "^4.13.4",
     "istanbul": "0.4.2",
     "mocha": "2.4.5",
     "split": "1.0.0",
@@ -32,6 +34,7 @@
   },
   "scripts": {
     "test": "mocha --check-leaks --reporter spec --bail",
+    "test:watch": "npm test -- --watch",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
   }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+var express = require('express')
+var morgan = require('./index')
+
+var app = express()
+app.use(morgan(':id :method :url :response-time'))
+app.use(morgan('clever'))
+
+app.get('/', function (req, res) {
+    res.send('this is /')
+})
+
+app.get('/hello/world', function (req, res) {
+    res.send('hello, world!')
+})
+
+app.listen(3000, function () {
+    console.log('Example app listening on port 3000!');
+});


### PR DESCRIPTION
Here's a prototype of node request middleware, extending `morgan`. We can decide whether to continue to extend morgan or remove all unnnecessary parts, later.

To add this middleware, currently it is invoked via `app.use(morgan('clever'))`

----

Start the express server

```
npm install
node server.js
```

Calling `curl "localhost:3000/hello/world?a=1&b=2"` results in this log being produced:

````
{"method":"GET","path":"/hello/world","params":"?a=1&b=2","response-size":"13","response-time":792955,"status-code":200}
```