### PR TITLE
Adding 'local' format to date token

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The current date and time in UTC. The available formats are:
   - `clf` for the common log format (`"10/Oct/2000:13:55:36 +0000"`)
   - `iso` for the common ISO 8601 date time format (`2000-10-10T13:55:36.000Z`)
   - `web` for the common RFC 1123 date time format (`Tue, 10 Oct 2000 13:55:36 GMT`)
+  - `local` for the local string format (`"10/Oct/2000:15:55:36 UTC+2"`)
 
 If no format is given, then the default is `web`.
 

--- a/index.js
+++ b/index.js
@@ -253,6 +253,8 @@ morgan.token('date', function getDateToken (req, res, format) {
       return date.toISOString()
     case 'web':
       return date.toUTCString()
+    case 'local':
+      return localdate(date)
   }
 })
 
@@ -360,6 +362,29 @@ function clfdate (dateTime) {
   return pad2(date) + '/' + month + '/' + year +
     ':' + pad2(hour) + ':' + pad2(mins) + ':' + pad2(secs) +
     ' +0000'
+}
+
+/**
+ * Format a Date in a local log format.
+ *
+ * @private
+ * @param {Date} dateTime
+ * @return {string}
+ */
+
+function localdate(dateTime) {
+  var date = dateTime.getDate()
+  var hour = dateTime.getHours()
+  var mins = dateTime.getMinutes()
+  var secs = dateTime.getSeconds()
+  var year = dateTime.getFullYear()
+  var offset = dateTime.getTimezoneOffset()
+
+  var month = CLF_MONTH[dateTime.getMonth()]
+
+  return pad2(date) + '/' + month + '/' + year
+    + ':' + pad2(hour) + ':' + pad2(mins) + ':' + pad2(secs)
+    + ' UTC' + minToHour(offset)
 }
 
 /**
@@ -505,4 +530,18 @@ function recordStartTime () {
 function token (name, fn) {
   morgan[name] = fn
   return this
+}
+
+/**
+ * Convert offset minutes into hours
+ *
+ * @private
+ * @param {offset} offset
+ * @return {string}
+ */
+
+function minToHour(offset) {
+  var sign = String(offset).substring(0, 1)
+  var min = String(offset).slice(1)
+  return (sign === '+' ? '-' : '+') + String(min / 60)
 }

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -207,6 +207,22 @@ describe('morgan()', function () {
         .expect(200, cb)
       })
 
+      it('should get current date in "local" format', function (done) {
+        var cb = after(2, function (err, res, line) {
+          if (err) return done(err)
+          assert.ok(/^\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} UTC[+-]\d$/.test(line))
+          done()
+        })
+
+        var stream = createLineStream(function (line) {
+          cb(null, null, line)
+        })
+
+        request(createServer(':date[local]', { stream: stream }))
+        .get('/')
+        .expect(200, cb)
+      })
+
       it('should be blank for unknown format', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)


### PR DESCRIPTION
A small patch to add a local format to the date token. It uses a format similar to clf using the current local time instead of UTC.