### PR TITLE
make tests for custom token() usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ function compile (format) {
   }
 
   var fmt = format.replace(/"/g, '\\"')
-  var js = '  "use strict"\n  return "' + fmt.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function (_, name, arg) {
+  var js = '  "use strict"\n  return "' + fmt.replace(/:([-\w]{2,})(?:\[([^\]]*)\])?/g, function (_, name, arg) {
     var tokenArguments = 'req, res'
     var tokenFunction = 'tokens[' + String(JSON.stringify(name)) + ']'
 

--- a/index.js
+++ b/index.js
@@ -383,6 +383,9 @@ function compile (format) {
     if (arg !== undefined) {
       tokenArguments += ', ' + String(JSON.stringify(arg))
     }
+    else {
+      tokenArguments += ', undefined'
+    }
 
     return '" +\n    (' + tokenFunction + '(' + tokenArguments + ') || "-") + "'
   }) + '"'

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1366,15 +1366,14 @@ describe('morgan.token(name, function)', function () {
     })
   })
 
-  it('should not see empty brackets as an argument value', function (done) {
+  it('should see empty brackets as an argument value', function (done) {
     morgan.token('checkempty', function ret (req, res, arg) {
-      assert.equal(arg, undefined)
-      assert.equal(arguments.length, 2)
+      assert.equal(arg, '')
       cb(null)
     })
     var cb = after(3, function (err, res, line) {
       if (err) return done(err)
-      assert.equal(line, '-[]')
+      assert.equal(line, '-')
       done()
     })
 
@@ -1382,9 +1381,7 @@ describe('morgan.token(name, function)', function () {
       cb(null, null, line)
     })
 
-    var server = createServer(':checkempty[]', { stream: stream }, function (req, res, next) {
-      next()
-    })
+    var server = createServer(':checkempty[]', { stream: stream })
 
     request(server)
     .get('/')
@@ -1405,11 +1402,12 @@ describe('morgan.token(name, function)', function () {
       cb(null, null, line)
     })
 
-    var server = createServer(':urlpart[query]', { stream: stream }, function (req, res, next) {
-      next()
-    })
+    var server = createServer(':urlpart[query]', { stream: stream })
 
-    request(server).post('/test').query('foo=bar').expect(200, cb)
+    request(server)
+    .post('/test')
+    .query('foo=bar')
+    .expect(200, cb)
   })
 })
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1330,9 +1330,9 @@ describe('morgan.token(name, function)', function () {
   })
 
   describe('should use the string `-` if return value of the token function is falsey', function () {
-    function test (v, done) {
-      morgan.token('ret', function ret (req, res, arg) {
-        return arg
+    it('for NaN', function (done) {
+      morgan.token('NaN', function ret (req, res, arg) {
+        return NaN
       })
       var cb = after(2, function (err, res, line) {
         if (err) return done(err)
@@ -1344,25 +1344,111 @@ describe('morgan.token(name, function)', function () {
         cb(null, null, line)
       })
 
-      var server = createServer(':ret', { stream: stream }, function (req, res, next) {
-        next()
-      })
+      var server = createServer(':NaN', { stream: stream })
 
       request(server)
       .get('/')
       .expect(200, cb)
-    }
-    [
-      0,
-      NaN,
-      false,
-      '',
-      null,
-      undefined
-    ].forEach(function (v) {
-      it('for ' + (String(v) || JSON.stringify(v)), function (done) {
-        test(v, done)
+    })
+    it('for 0', function (done) {
+      morgan.token('zero', function ret (req, res, arg) {
+        return 0
       })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':zero', { stream: stream })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    })
+    it('for undefined', function (done) {
+      morgan.token('undefined', function ret (req, res, arg) {
+        return undefined
+      })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':undefined', { stream: stream })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    })
+    it('for null', function (done) {
+      morgan.token('null', function ret (req, res, arg) {
+        return null
+      })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':null', { stream: stream })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    })
+    it('for ""', function (done) {
+      morgan.token('empty', function ret (req, res, arg) {
+        return ''
+      })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':empty', { stream: stream })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    })
+    it('for false', function (done) {
+      morgan.token('false', function ret (req, res, arg) {
+        return false
+      })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':false', { stream: stream })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
     })
   })
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -7,6 +7,7 @@ var join = require('path').join
 var morgan = require('..')
 var request = require('supertest')
 var split = require('split')
+var url = require('url')
 
 describe('morgan()', function () {
   describe('arguments', function () {
@@ -1313,6 +1314,102 @@ describe('morgan.compile(format)', function () {
         assert.ok(fn.length === 3)
       })
     })
+  })
+})
+
+describe('morgan.token(name, function)', function () {
+  it('should overwrite existing functions if called multiple times', function (done) {
+    function token (req, res, arg) {
+      return arg && url.parse(req.url)[arg]
+    }
+    var urlToken = morgan.url
+    morgan.token('url', token)
+    assert.equal(morgan.url, token)
+    morgan.token('url', urlToken)
+    done()
+  })
+
+  describe('should use the string `-` if return value of the token function is falsey', function () {
+    function test (v, done) {
+      morgan.token('ret', function ret (req, res, arg) {
+        return arg
+      })
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.equal(line, '-')
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      var server = createServer(':ret', { stream: stream }, function (req, res, next) {
+        next()
+      })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    }
+    [
+      0,
+      NaN,
+      false,
+      '',
+      null,
+      undefined
+    ].forEach(function (v) {
+      it('for ' + (String(v) || JSON.stringify(v)), function (done) {
+        test(v, done)
+      })
+    })
+  })
+
+  it('should not see empty brackets as an argument value', function (done) {
+    morgan.token('checkempty', function ret (req, res, arg) {
+      assert.equal(arg, undefined)
+      assert.equal(arguments.length, 2)
+      cb(null)
+    })
+    var cb = after(3, function (err, res, line) {
+      if (err) return done(err)
+      assert.equal(line, '-[]')
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var server = createServer(':checkempty[]', { stream: stream }, function (req, res, next) {
+      next()
+    })
+
+    request(server)
+    .get('/')
+    .expect(200, cb)
+  })
+
+  it('should use the result', function (done) {
+    morgan.token('urlpart', function ret (req, res, arg) {
+      return url.parse(req.url)[arg]
+    })
+    var cb = after(2, function (err, res, line) {
+      if (err) return done(err)
+      assert.equal(line, 'foo=bar')
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var server = createServer(':urlpart[query]', { stream: stream }, function (req, res, next) {
+      next()
+    })
+
+    request(server).post('/test').query('foo=bar').expect(200, cb)
   })
 })
 


### PR DESCRIPTION
Superseding https://github.com/expressjs/morgan/pull/124

* fixes parsing of empty arguments via `:x[]`
* makes token functions always be given the same length of arguments

Makes tests for custom usage of `morgan.token` from reading the docs.