### PR TITLE
Add objectMode option for objectMode streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ morgan('combined', {
 
 Output stream for writing log lines, defaults to `process.stdout`.
 
+##### objectMode
+
+Interpret log lines as objects when writing to `stream`.
+
 #### Predefined Formats
 
 There are various pre-defined formats provided:

--- a/index.js
+++ b/index.js
@@ -75,6 +75,9 @@ function morgan (format, options) {
   // output on request instead of response
   var immediate = opts.immediate
 
+  // output to an objectMode stream
+  var objectMode = opts.objectMode
+
   // check if log entry should be skipped
   var skip = opts.skip || false
 
@@ -127,6 +130,11 @@ function morgan (format, options) {
       }
 
       debug('log request')
+      if (objectMode) {
+        stream.write(line)
+        return
+      }
+
       stream.write(line + '\n')
     };
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1298,7 +1298,7 @@ describe('morgan()', function () {
         done()
       })
 
-      function format(tokens, req, res) {
+      function format (tokens, req, res) {
         return {
           method: tokens.method(req, res),
           url: tokens.url(req, res),
@@ -1308,9 +1308,9 @@ describe('morgan()', function () {
 
       var stream = {
         write: function (obj) {
-          assert.equal(obj.method, 'GET');
-          assert.equal(obj.url, '/');
-          assert.equal(obj.status, 200);
+          assert.equal(obj.method, 'GET')
+          assert.equal(obj.url, '/')
+          assert.equal(obj.status, 200)
         }
       }
 
@@ -1322,8 +1322,8 @@ describe('morgan()', function () {
       request(server)
       .get('/')
       .expect(200, cb)
-    });
-  });
+    })
+  })
 })
 
 describe('morgan.compile(format)', function () {

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1290,6 +1290,40 @@ describe('morgan()', function () {
       .expect(200, done)
     })
   })
+
+  describe('with objectMode option', function () {
+    it('should write the literal object value', function (done) {
+      var cb = after(1, function (err) {
+        if (err) return done(err)
+        done()
+      })
+
+      function format(tokens, req, res) {
+        return {
+          method: tokens.method(req, res),
+          url: tokens.url(req, res),
+          status: tokens.status(req, res)
+        }
+      }
+
+      var stream = {
+        write: function (obj) {
+          assert.equal(obj.method, 'GET');
+          assert.equal(obj.url, '/');
+          assert.equal(obj.status, 200);
+        }
+      }
+
+      var server = createServer(format, {
+        stream: stream,
+        objectMode: true
+      })
+
+      request(server)
+      .get('/')
+      .expect(200, cb)
+    });
+  });
 })
 
 describe('morgan.compile(format)', function () {


### PR DESCRIPTION
This is necessary if you want to log the results of `morgan` to another system which performs serialization itself. e.g. interop with other logging libraries like `winston` using `meta` instead of writing a single log line:

``` js
var winston = require('winston')
var morgan = require('morgan')
var express = require('express')

var app = express()

app.use(morgan(function (tokens, req, res) {
  return {
    method: tokens.method(req, res),
    url: tokens.url(req, res),
    status: tokens.status(req, res)
  }
}, {
  stream: function (meta) { winston.info('Request served', meta) },
  objectMode: true
})
```

without `objectMode: true` in the above example `winston` would output:

```
Request served [object Object]\n
```

Given that `objectMode` streams are a very common use-case for streams this seems like an essential addition to `morgan`.
