### PR TITLE
Add ability to silent morgan, useful when doing tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = morgan
 module.exports.compile = compile
 module.exports.format = format
 module.exports.token = token
+module.exports.silent = false
 
 /**
  * Module dependencies.
@@ -101,6 +102,10 @@ function morgan (format, options) {
   }
 
   return function logger (req, res, next) {
+
+    if (module.exports.silent)
+      return next()
+
     // request data
     req._startAt = undefined
     req._startTime = undefined

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1290,6 +1290,26 @@ describe('morgan()', function () {
       .expect(200, done)
     })
   })
+
+  describe('on silent mode', function () {
+
+    before(function () { 
+      morgan.silent = true 
+    })
+    after(function () {
+      morgan.silent = false
+    })
+    
+    it ('should not log any output', function (done) {
+      var stream = createLineStream(function () {
+        throw new Error('should not log line')
+      })
+
+      request(createServer({ format: 'default', stream: stream }))
+      .get('/')
+      .expect(200, done)
+    })
+  })
 })
 
 describe('morgan.compile(format)', function () {


### PR DESCRIPTION
I'm running mock tests with a dummy server, and find that too many logs are polluting my test results screen. Always wanted to have some mechanism to suppress log output.

Usage:
`morgan.silent = true`