### PR TITLE
fixed additon of '\n' to non strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function morgan (format, options) {
       }
 
       debug('log request')
-      stream.write(line + '\n')
+      stream.write(typeof line === 'string' ? (line + '\n') : line)
     };
 
     if (immediate) {


### PR DESCRIPTION
I'm using morgan to write objects into a stream (winston). Because of the + '\n', morgan always writes '[object Object] \n'