### PR TITLE
Added checks for unidentified format

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ function morgan (format, options) {
     deprecate('undefined format: specify a format')
   }
 
+  if (morgan[fmt] === undefined) {
+    deprecate('unidentified format: specify a proper format')
+  }
+
   // output on request instead of response
   var immediate = opts.immediate
 

--- a/index.js
+++ b/index.js
@@ -72,8 +72,11 @@ function morgan (format, options) {
     deprecate('undefined format: specify a format')
   }
 
-  if (morgan[fmt] === undefined) {
-    deprecate('unidentified format: specify a proper format')
+  if (typeof fmt === 'string' && morgan[fmt] === undefined) {
+    if(fmt.split(':').length <= 1) {
+      deprecate('unidentified format: specify a proper format')
+      fmt = 'default'
+    }
   }
 
   // output on request instead of response

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function morgan (format, options) {
   }
 
   if (typeof fmt === 'string' && morgan[fmt] === undefined) {
-    if(fmt.split(':').length <= 1) {
+    if (fmt.split(':').length <= 1) {
       deprecate('unidentified format: specify a proper format')
       fmt = 'default'
     }

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -27,6 +27,22 @@ describe('morgan()', function () {
       .expect(200, cb)
     })
 
+    it('should throw warnings for unspecified format', function (done) {
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert(res.text.length > 0)
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      request(createServer('random', { stream: stream }))
+      .get('/')
+      .expect(200, cb)
+    })
+
     describe('format', function () {
       it('should accept format as format name', function (done) {
         var cb = after(2, function (err, res, line) {


### PR DESCRIPTION
I have added checks for format which is not specified in morgan. For eg. if user writes
`app.use(morgan("random"))` 
it is just printing random instead of logs in the console without any warnings.