### PR TITLE
Make Morgan easier to use with web frameworks that do not have middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ function morgan (format, options) {
       onFinished(res, logRequest)
     }
 
-    next()
+    if (next) {
+      next()
+    }
   }
 }
 


### PR DESCRIPTION
I recently successfully and pretty painlessly implemented morgan into micro - https://github.com/zeit/micro.
The implementation looks something like this:

```
function(req, res) { // micro's http server function
    morgan('short')(req, res, function() {});
}
```

See the empty function? Morgan throws an exception if I don't pass it a `next` function,  which does not exist in micro.

This PR has morgan only calling `next()` if it is passed to morgan, which should remove the necessary empty function for web frameworks without middleware support, while not harming any preexisting implementations. Let me know what you think.