### PR TITLE
Record response time at response end instead of response start

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Add `:total-time` token
   * Fix trailing space in colored status code for `dev` format
   * deps: basic-auth@~2.0.1
      - deps: safe-buffer@5.1.2

--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ If the request/response cycle completes before a response was sent to the
 client (for example, the TCP socket closed prematurely by a client aborting
 the request), then the status will be empty (displayed as `"-"` in the log).
 
+##### :total-time[digits]
+
+The time between the request coming into `morgan` and when the response
+has finished being written out to the connection, in milliseconds.
+
+The `digits` argument is a number that specifies the number of digits to
+include on the number, defaulting to `3`, which provides microsecond precision.
+
 ##### :url
 
 The URL of the request. This will use `req.originalUrl` if exists, otherwise `req.url`.

--- a/index.js
+++ b/index.js
@@ -240,6 +240,26 @@ morgan.token('response-time', function getResponseTimeToken (req, res, digits) {
 })
 
 /**
+ * total time in milliseconds
+ */
+
+morgan.token('total-time', function getTotalTimeToken (req, res, digits) {
+  if (!req._startAt || !res._startAt) {
+    // missing request and/or response start time
+    return
+  }
+
+  // time elapsed from request start
+  var elapsed = process.hrtime(req._startAt)
+
+  // cover to milliseconds
+  var ms = (elapsed[0] * 1e3) + (elapsed[1] * 1e-6)
+
+  // return truncated value
+  return ms.toFixed(digits === undefined ? 3 : digits)
+})
+
+/**
  * current date
  */
 


### PR DESCRIPTION
Should record response time at response end instead of response start so that we can record whole response time for streaming response.