### PR TITLE
Remove additional space from colored status code

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix trailing space in colored status code for `dev` format
   * deps: basic-auth@~2.0.1
      - deps: safe-buffer@5.1.2
 

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
   if (!fn) {
     // compile
     fn = developmentFormatLine[color] = compile('\x1b[0m:method :url \x1b[' +
-      color + 'm:status \x1b[0m:response-time ms - :res[content-length]\x1b[0m')
+      color + 'm:status\x1b[0m :response-time ms - :res[content-length]\x1b[0m')
   }
 
   return fn(tokens, req, res)

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1020,7 +1020,7 @@ describe('morgan()', function () {
       it('should not color 1xx', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
-          assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_0_102 _color_0_')
+          assert.strictEqual(line.substr(0, 36), '_color_0_GET / _color_0_102_color_0_')
           assert.strictEqual(line.substr(-9), '_color_0_')
           done()
         })
@@ -1042,7 +1042,7 @@ describe('morgan()', function () {
       it('should color 2xx green', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
-          assert.strictEqual(line.substr(0, 38), '_color_0_GET / _color_32_200 _color_0_')
+          assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_32_200_color_0_')
           assert.strictEqual(line.substr(-9), '_color_0_')
           done()
         })
@@ -1064,7 +1064,7 @@ describe('morgan()', function () {
       it('should color 3xx cyan', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
-          assert.strictEqual(line.substr(0, 38), '_color_0_GET / _color_36_300 _color_0_')
+          assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_36_300_color_0_')
           assert.strictEqual(line.substr(-9), '_color_0_')
           done()
         })
@@ -1086,7 +1086,7 @@ describe('morgan()', function () {
       it('should color 4xx yelow', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
-          assert.strictEqual(line.substr(0, 38), '_color_0_GET / _color_33_400 _color_0_')
+          assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_33_400_color_0_')
           assert.strictEqual(line.substr(-9), '_color_0_')
           done()
         })
@@ -1108,7 +1108,7 @@ describe('morgan()', function () {
       it('should color 5xx red', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
-          assert.strictEqual(line.substr(0, 38), '_color_0_GET / _color_31_500 _color_0_')
+          assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_31_500_color_0_')
           assert.strictEqual(line.substr(-9), '_color_0_')
           done()
         })
@@ -1131,7 +1131,7 @@ describe('morgan()', function () {
         it('should not have color or response values', function (done) {
           var cb = after(2, function (err, res, line) {
             if (err) return done(err)
-            assert.strictEqual(line, '_color_0_GET / _color_0_- _color_0_- ms - -_color_0_')
+            assert.strictEqual(line, '_color_0_GET / _color_0_-_color_0_ - ms - -_color_0_')
             done()
           })
 


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/1016523/43044601-2823461e-8dba-11e8-8e7c-f66f77f67e08.png)

**After:**

![image](https://user-images.githubusercontent.com/1016523/43044593-044de244-8dba-11e8-9adb-845cd749cf4d.png)
