### PR TITLE
new line format

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,8 @@ function morgan (format, options) {
     deprecate('morgan(options): use morgan(' + (typeof fmt === 'string' ? JSON.stringify(fmt) : 'format') + ', options) instead')
   }
 
+  opts.newLineFormat = (options && options.newLineFormat !== undefined && options.newLineFormat !== null) ? options.newLineFormat : '\n'
+
   if (fmt === undefined) {
     deprecate('undefined format: specify a format')
   }
@@ -127,7 +129,7 @@ function morgan (format, options) {
       }
 
       debug('log request')
-      stream.write(line + '\n')
+      stream.write(line + opts.newLineFormat)
     };
 
     if (immediate) {


### PR DESCRIPTION
Morgan prints new line at the end of every log. It causes our AWS logs full of empty lines and makes it hard to detect and trace bugs. That's why I added an option - 'newLineFormat' . If this option does not exist - the fallback is '\n'. 
Our use case will be {newLineFormat: ''}