### PR TITLE
Added enableObjectStream option

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,12 +79,14 @@ function morgan (format, options) {
   var skip = opts.skip || false
 
   // format function
-  var formatLine = typeof fmt !== 'function'
+  var isFormatFunction = typeof fmt === 'function'
+  var formatLine = !isFormatFunction
     ? getFormatFunction(fmt)
     : fmt
 
   // stream
   var buffer = opts.buffer
+  var isStreamDefined = !!opts.stream
   var stream = opts.stream || process.stdout
 
   // buffering support
@@ -126,8 +128,13 @@ function morgan (format, options) {
         return
       }
 
-      debug('log request')
-      stream.write(line + '\n')
+      if (opts.enableObjectStream && isStreamDefined && isFormatFunction) {
+        debug('log request without newline character')
+        stream.write(line)
+      } else {
+        debug('log request')
+        stream.write(line + '\n')
+      }
     };
 
     if (immediate) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "on-headers": "~1.0.1"
   },
   "devDependencies": {
-    "eslint": "5.9.0",
+    "eslint": "5.10.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-markdown": "1.0.0-rc.0",

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1391,7 +1391,11 @@ describe('morgan()', function () {
         }
       }
 
-      request(createServer((tokens, req, res) => ({ get: tokens.method(req, res) }), { enableObjectStream: true, stream: customStream }))
+      var customFormatFunction = function (tokens, req, res) {
+        return { get: tokens.method(req, res) }
+      }
+
+      request(createServer(customFormatFunction, { enableObjectStream: true, stream: customStream }))
         .get('/fakeEndpoint')
         .expect(200, cb)
     })
@@ -1422,7 +1426,7 @@ describe('morgan()', function () {
       var cb = after(2, function (err, res, line) {
         if (err) return done(err)
         assert(res.text.length > 0)
-        assert(typeof line === "string")
+        assert(typeof line === 'string')
         done()
       })
 
@@ -1433,7 +1437,11 @@ describe('morgan()', function () {
       Object.defineProperty(process, 'stdout', {
         value: stream
       })
-      request(createServer((tokens, req, res) => ({ get: tokens.method(req, res) }), { enableObjectStream: true, stream: undefined }))
+
+      var customFormatFunction = function (tokens, req, res) {
+        return { get: tokens.method(req, res) }
+      }
+      request(createServer(customFormatFunction, { enableObjectStream: true, stream: undefined }))
         .get('/')
         .expect(200, cb)
     })

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1381,7 +1381,7 @@ describe('morgan()', function () {
     it('should write an Object to stream based on the custom format function', function (done) {
       var cb = after(2, function (err, res, streamOutput) {
         if (err) return done(err)
-        assert.deepEqual(streamOutput, { get: 'GET' })
+        assert.deepStrictEqual(streamOutput, { get: 'GET' })
         done()
       })
 

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1381,7 +1381,8 @@ describe('morgan()', function () {
     it('should write an Object to stream based on the custom format function', function (done) {
       var cb = after(2, function (err, res, streamOutput) {
         if (err) return done(err)
-        assert.deepStrictEqual(streamOutput, { get: 'GET' })
+        assert(typeof streamOutput === 'object')
+        assert(streamOutput.get === 'GET')
         done()
       })
 


### PR DESCRIPTION
## Background 

I've got a similar use case with the issue raised: https://github.com/expressjs/morgan/issues/181. 

I am using Morgan for a lot of my projects and I would like to be able to write an Object in a stream instead of just a string.

Reason is that I am using Winston which supports meta-data for reach-er logs. I would like to use morgan and pass an object to Winston - instead of parsing a string. 

## Changes
- Added a **backwards compatible** `enableObjectStream` in morgan() call. 
 - Defaults to false
- It needs a custom format function and a defined stream to work.
- The only diff is that if the above are true (`customFormatFunction && stream && enableObjectStream`), we are not concatenating a `\n` (newline char), hence morgan can stream an object.

Any improvements/changes are welcome.

TODO:
- Update README
- Update HISTORY

but I'd like to get some opinions first 😄 

