### PR TITLE
Update list of dev colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Standard Apache common log output.
 ##### dev
 
 Concise output colored by response status for development use. The `:status`
-token will be colored red for server error codes, yellow for client error
-codes, cyan for redirection codes, and uncolored for all other codes.
+token will be colored green for success codes, red for server error codes,
+yellow for client error codes, cyan for redirection codes, and uncolored
+for information codes.
 
 ```
 :method :url :status :response-time ms - :res[content-length]


### PR DESCRIPTION
In the `dev` preset, success codes (2xx) are [colored green](https://github.com/expressjs/morgan/blob/master/index.js#L193). This change updates the documentation to reflect that.