### PR TITLE
Fix deprecation warning for node12 LTS

### DIFF
--- a/index.js
+++ b/index.js
@@ -478,8 +478,12 @@ function getip (req) {
  */
 
 function headersSent (res) {
+  var isHeadersAlreadySent = res.getHeaders
+    ? res.getHeaders()
+    : res._headers
+
   return typeof res.headersSent !== 'boolean'
-    ? Boolean(res.getHeaders())
+    ? Boolean(isHeadersAlreadySent)
     : res.headersSent
 }
 

--- a/index.js
+++ b/index.js
@@ -479,7 +479,7 @@ function getip (req) {
 
 function headersSent (res) {
   return typeof res.headersSent !== 'boolean'
-    ? Boolean(res._header)
+    ? Boolean(res.getHeaders())
     : res.headersSent
 }
 


### PR DESCRIPTION
https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames

Each time this function is called, we have a warning in console output.

`(node:21443) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated`