### PR TITLE
Add record json response option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ morgan('combined', {
 })
 ```
 
+##### recordJsonResponse
+
+Record response body in `res.body`, just apply this rule at response with `application/json` header.
+
 ##### stream
 
 Output stream for writing log lines, defaults to `process.stdout`.

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1376,6 +1376,28 @@ describe('morgan()', function () {
         .expect(200, done)
     })
   })
+
+  describe('with recordJsonResponse option', function () {
+    it('should be able to record response body in res.body', function (done) {
+      const response = '65535'
+
+      var cb = after(2, function (err, res, line) {
+        if (err) return done(err)
+        assert.strictEqual(res.body, JSON.parse(response))
+        assert.strictEqual(line, response)
+        done()
+      })
+
+      var stream = createLineStream(function (line) {
+        cb(null, null, line)
+      })
+
+      request(createServer(':response-body', { stream: stream, recordJsonResponse: true }, (req, res, next) => { res.end(response) },
+        (res, req) => req.setHeader('content-type', 'application/json')))
+        .get('/?recordJsonResponse=true')
+        .expect(200, cb)
+    })
+  })
 })
 
 describe('morgan.compile(format)', function () {


### PR DESCRIPTION
Hello, I have added `recordJsonResponse` option to record the response body if this response with `application/json` header.
I think if I want to record a response in log, this is necessary.
The reference for this implementation: [https://github.com/bithavoc/express-winston](url)