### PR TITLE
update readme to note rfs specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ app.get('/', function (req, res) {
 Simple app that will log all requests in the Apache combined format to one log
 file per day in the `log/` directory using the
 [rotating-file-stream module](https://www.npmjs.com/package/rotating-file-stream).
+This example specifically works with [rotating-file-stream module](https://www.npmjs.com/package/rotating-file-stream) version `1.4.6` and below. For use with later versions [see the upgrading guide](https://github.com/iccicci/rotating-file-stream#upgrading-from-v1xx-to-v2xx).
 
 ```js
 var express = require('express')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "on-headers": "~1.0.1"
   },
   "devDependencies": {
-    "eslint": "5.9.0",
+    "eslint": "5.10.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-markdown": "1.0.0-rc.0",


### PR DESCRIPTION
Addresses @dougwilson request in https://github.com/expressjs/morgan/pull/218#pullrequestreview-343393630.

As of November 2019 the [rotating-file-stream](https://github.com/iccicci/rotating-file-stream#upgrading-from-v1xx-to-v2xx) package moved from 1.x.x to 2.x.x.

The main breaking change was what is described in #217 and fixed in the docs at #218 