### PR TITLE
Updating code example for logging on rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,17 +320,17 @@ var app = express()
 
 // function for creating names for files
 const generateName = (date) => {
-return new Date(date)
-		.toLocaleDateString()
-		.replace(/\//g, "-")
-		.concat(".log")
+  return new Date(date)
+    .toLocaleDateString()
+    .replace(/\//g, '-')
+    .concat('.log')
 }
 
 // create a rotating write stream
 const accessLogStream = rfs.createStream(generateName, {
-	interval: "1d", // rotate daily
-	immutable: true,
-	path: path.join(__dirname, 'log')
+  interval: '1d', // rotate daily
+  immutable: true,
+  path: path.join(__dirname, 'log')
 })
 
 // setup the logger

--- a/README.md
+++ b/README.md
@@ -318,10 +318,19 @@ var rfs = require('rotating-file-stream')
 
 var app = express()
 
+// function for creating names for files
+const generateName = (date) => {
+return new Date(date)
+		.toLocaleDateString()
+		.replace(/\//g, "-")
+		.concat(".log")
+}
+
 // create a rotating write stream
-var accessLogStream = rfs('access.log', {
-  interval: '1d', // rotate daily
-  path: path.join(__dirname, 'log')
+const accessLogStream = rfs.createStream(generateName, {
+	interval: "1d", // rotate daily
+	immutable: true,
+	path: path.join(__dirname, 'log')
 })
 
 // setup the logger


### PR DESCRIPTION
'rotating-file-stream' api has changed and most people will install the latest. So the example should adapt to that.
Also the previous code example was incomplete and left many people wondering about details of implementation.
My example is complete and short. Anyone can copy-paste it and get it immediately working. No need to go to the 'rotating-file-stream' library and read its documentation!