### PR TITLE
mocking date for a test to ensure pad2 runs with single digit dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "debug": "2.6.9",
     "depd": "~2.0.0",
     "on-finished": "~2.3.0",
-    "on-headers": "~1.0.2"
+    "on-headers": "~1.0.2",
+    "sinon": "2.0.0"
   },
   "devDependencies": {
     "eslint": "5.16.0",
@@ -31,6 +32,7 @@
     "eslint-plugin-standard": "4.0.0",
     "istanbul": "0.4.5",
     "mocha": "6.1.4",
+    "sinon": "2.0.0",
     "split": "1.0.1",
     "supertest": "3.3.0"
   },

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -9,6 +9,7 @@ var join = require('path').join
 var morgan = require('..')
 var request = require('supertest')
 var split = require('split')
+var sinon = require('sinon')
 
 describe('morgan()', function () {
   describe('arguments', function () {
@@ -207,6 +208,24 @@ describe('morgan()', function () {
         })
 
         request(createServer(':date', { stream: stream }))
+          .get('/')
+          .expect(200, cb)
+      })
+
+      it('should handle dates with single digits when using "clf" format', function (done) {
+        var clock = sinon.useFakeTimers(new Date('2020-02-27').getTime())
+        var cb = after(2, function (err, res, line) {
+          if (err) return done(err)
+          assert.ok(/^\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000$/.test(line))
+          clock.restore()
+          done()
+        })
+
+        var stream = createLineStream(function (line) {
+          cb(null, null, line)
+        })
+
+        request(createServer(':date[clf]', { stream: stream }))
           .get('/')
           .expect(200, cb)
       })


### PR DESCRIPTION
This PR adds a test to always make sure `pad2` is covered.  When running tests, if every value passed to `pad2` is two digits (which depends on the time the tests are run), a drop in coverage can happen. 

To mock the date I added `sinon@4.0.0.` as a dependency.  `4.0.0` was used as it was the last version I could find that had an `engines` field for the versions of node this library has to support: https://github.com/sinonjs/sinon/blob/v4.0.0/package.json#L91-L93