### PR TITLE
adding istanbul ignore for pad2

### DIFF
--- a/index.js
+++ b/index.js
@@ -495,6 +495,7 @@ function headersSent (res) {
 function pad2 (num) {
   var str = String(num)
 
+  // istanbul ignore next: num is current datetime
   return (str.length === 1 ? '0' : '') + str
 }
 


### PR DESCRIPTION
Related issue: https://github.com/expressjs/morgan/issues/228

I'm open to an alternative here.  I tried adding `sinon@2.0.0` (the oldest version I could install) so I could write a new test with a mocked date; however, sinon wouldn't install correctly in older versions of node https://github.com/expressjs/morgan/pull/226. 