### PR TITLE
renaming simple to sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ advanced uses, this compile function is directly available.
 
 ### express/connect
 
-Simple app that will log all request in the Apache combined format to STDOUT
+Sample app that will log all request in the Apache combined format to STDOUT
 
 ```js
 var express = require('express')
@@ -265,7 +265,7 @@ app.get('/', function (req, res) {
 
 ### vanilla http server
 
-Simple app that will log all request in the Apache combined format to STDOUT
+Sample app that will log all request in the Apache combined format to STDOUT
 
 ```js
 var finalhandler = require('finalhandler')
@@ -291,7 +291,7 @@ http.createServer(function (req, res) {
 
 #### single file
 
-Simple app that will log all requests in the Apache combined format to the file
+Sample app that will log all requests in the Apache combined format to the file
 `access.log`.
 
 ```js
@@ -315,7 +315,7 @@ app.get('/', function (req, res) {
 
 #### log file rotation
 
-Simple app that will log all requests in the Apache combined format to one log
+Sample app that will log all requests in the Apache combined format to one log
 file per day in the `log/` directory using the
 [rotating-file-stream module](https://www.npmjs.com/package/rotating-file-stream).
 


### PR DESCRIPTION
simple is relative and another app in the examples used `sample`