### PR TITLE
move formats one level under the morgan object

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,8 @@ function morgan (format, options) {
   }
 }
 
+morgan.formats = {}
+
 /**
  * Apache combined log format.
  */
@@ -162,7 +164,7 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  */
 
 morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
-deprecate.property(morgan, 'default', 'default format: use combined format')
+deprecate.property(morgan.formats, 'default', 'default format: use combined format')
 
 /**
  * Short format.
@@ -452,7 +454,7 @@ function createBufferStream (stream, interval) {
  */
 
 function format (name, fmt) {
-  morgan[name] = fmt
+  morgan.formats[name] = fmt
   return this
 }
 
@@ -466,7 +468,7 @@ function format (name, fmt) {
 
 function getFormatFunction (name) {
   // lookup format
-  var fmt = morgan[name] || name || morgan.default
+  var fmt = morgan.formats[name] || name || morgan.formats.default
 
   // return compiled format
   return typeof fmt !== 'function'


### PR DESCRIPTION
This PR would close https://github.com/expressjs/morgan/issues/190.  

Per my comment https://github.com/expressjs/morgan/issues/190#issuecomment-611829994, there is not an issue with using `import` syntax in the versions of node that support it. The issue is _only_ with using import syntax via the `esm` module.

If we'd rather not land something like this under 1.x I'm  fine with that call and am all for starting the work on v2 that removes the `default` format (along with other items) as noted here https://github.com/expressjs/morgan/issues/222.



