### PR TITLE
fix issue in field missing :req token

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ morgan.token('user-agent', function getUserAgentToken (req) {
 
 morgan.token('req', function getRequestToken (req, res, field) {
   if (!field) {
-    throw new Error('req is missing field')
+    throw new Error('req is missing an argument')
   }
 
   // get header

--- a/index.js
+++ b/index.js
@@ -335,16 +335,12 @@ morgan.token('user-agent', function getUserAgentToken (req) {
  */
 
 morgan.token('req', function getRequestToken (req, res, field) {
-  // get header
-  var header = req.rawHeaders;
-
-  if (field) {
-    field = field.toLowerCase();
-    header =
-      req.rawHeaders.map((item,idx,arr) => {
-        if ((item.toLowerCase() === field) && (idx < arr.length)) return arr[idx+1];
-      }).filter(item => item !== undefined);
+  if (!field) {
+    throw new Error('req is missing field')
   }
+
+  // get header
+  var header = req.headers[field.toLowerCase()];
 
   return Array.isArray(header)
     ? header.join(', ')

--- a/index.js
+++ b/index.js
@@ -336,11 +336,11 @@ morgan.token('user-agent', function getUserAgentToken (req) {
 
 morgan.token('req', function getRequestToken (req, res, field) {
   if (!field) {
-    throw new Error('req is missing an argument')
+    throw new TypeError('header argument is required to :req token')
   }
 
   // get header
-  var header = req.headers[field.toLowerCase()];
+  var header = req.headers[field.toLowerCase()]
 
   return Array.isArray(header)
     ? header.join(', ')

--- a/index.js
+++ b/index.js
@@ -336,7 +336,15 @@ morgan.token('user-agent', function getUserAgentToken (req) {
 
 morgan.token('req', function getRequestToken (req, res, field) {
   // get header
-  var header = req.headers[field.toLowerCase()]
+  var header = req.rawHeaders;
+
+  if (field) {
+    field = field.toLowerCase();
+    header =
+      req.rawHeaders.map((item,idx,arr) => {
+        if ((item.toLowerCase() === field) && (idx < arr.length)) return arr[idx+1];
+      }).filter(item => item !== undefined);
+  }
 
   return Array.isArray(header)
     ? header.join(', ')

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -295,6 +295,10 @@ describe('morgan()', function () {
     })
 
     describe(':req', function () {
+      it('should throw an error if no header provided', function () {
+        assert.throws(() => request(createServer(':req')).get('/'), /header argument is required to :req token/)
+      })
+
       it('should get request properties', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)


### PR DESCRIPTION
```
 var header = req.headers[field.toLowerCase()]
                                 ^
TypeError: Cannot read properties of undefined (reading 'toLowerCase')

Node.js v18.7.0
````
Missing field of req token causes the app to crash in this PR I fixed this issues with the following solution:

- In case user doesn't define a specific field of the response the code will log the whole header response
- If user defines its field the code will log just the value responding to the field itself.

I believe the code become more generic and it behaves correctly with various response headers.

All tests pass:
```
> morgan@1.10.0 test
> mocha --check-leaks --reporter spec --bail



  morgan()
    arguments
      ✓ should use default format
      format
        ✓ should accept format as format name
        ✓ should accept format as format string
        ✓ should accept format as function
        ✓ should reject format as bool
        back-compat
          ✓ should accept options object
          ✓ should accept format in options for back-compat
          ✓ should accept format function in options for back-compat
      stream
        ✓ should default to process.stdout
        ✓ should set stream to write logs to
    tokens
      :date
        ✓ should get current date in "web" format by default
        ✓ should get current date in "clf" format
        ✓ should get current date in "iso" format
        ✓ should get current date in "web" format
        ✓ should be blank for unknown format
      :http-version
        ✓ should be 1.0 or 1.1
      :req
        ✓ should get request properties
        ✓ should display all values of array headers
      :res
        ✓ should get response properties
        ✓ should display all values of array headers
      :remote-addr
        ✓ should get remote address
        ✓ should use req.ip if there
        ✓ should work on https server
        ✓ should work when connection: close
        ✓ should work when connection: keep-alive
        ✓ should work when req.ip is a getter
        ✓ should not fail if req.connection missing
      :remote-user
        ✓ should be empty if none present
        ✓ should support Basic authorization
        ✓ should be empty for empty Basic authorization user
      :response-time
        ✓ should be in milliseconds
        ✓ should have three digits by default
        ✓ should have five digits with argument "5"
        ✓ should have no digits with argument "0"
        ✓ should not include response write time (51ms)
        ✓ should be empty without hidden property
        ✓ should be empty before response
        ✓ should be empty if morgan invoked after response sent
      :status
        ✓ should get response status
        ✓ should not exist before response sent
        ✓ should not exist for aborted request
      :total-time
        ✓ should be in milliseconds
        ✓ should have three digits by default
        ✓ should have five digits with argument "5"
        ✓ should have no digits with argument "0"
        ✓ should include response write time (52ms)
        ✓ should be empty without hidden property
        ✓ should be empty before response
        ✓ should be empty if morgan invoked after response sent
      :url
        ✓ should get request URL
        ✓ should use req.originalUrl if exists
        ✓ should not exist for aborted request
    formats
      a function
        ✓ should log result of function
        ✓ should not log for undefined return
        ✓ should not log for null return
      a string
        ✓ should accept format as format string of tokens
        ✓ should accept text mixed with tokens
        ✓ should accept special characters
      combined
        ✓ should match expectations
      common
        ✓ should match expectations
      default
        ✓ should match expectations
      dev
        ✓ should not color 1xx
        ✓ should color 2xx green
        ✓ should color 3xx cyan
        ✓ should color 4xx yelow
        ✓ should color 5xx red
        with "immediate: true" option
          ✓ should not have color or response values
      short
        ✓ should match expectations
      tiny
        ✓ should match expectations
    with buffer option
      ✓ should flush log periodically (1003ms)
      ✓ should accept custom interval (206ms)
    with immediate option
      ✓ should not have value for :res
      ✓ should not have value for :response-time
      ✓ should not have value for :status
      ✓ should log before response
    with skip option
      ✓ should be able to skip based on request
      ✓ should be able to skip based on response

  morgan.compile(format)
    arguments
      format
        ✓ should be required
        ✓ should reject functions
        ✓ should reject numbers
        ✓ should compile a string into a function


  81 passing (1s)
  ```