### PR TITLE
Format functions may return objects for streams in objectMode

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,12 @@ function morgan (format, options) {
       }
 
       debug('log request')
-      stream.write(line + '\n')
+      if (stream.writableObjectMode && typeof line == 'object') {
+        stream.write(line)
+      }
+      else {
+        stream.write(line + '\n')
+      }
     };
 
     if (immediate) {


### PR DESCRIPTION
Currently Morgan converts the return value of a format function to string (by means of concatenating it with a new-line).  In some cases it would be convenient to allow objects returned by the format function to be passed directly to the stream, provided that the underlying stream can consume objects.

A stream that operates in "object mode" can operate on objects other than just strings and buffers.  (See [https://nodejs.org/docs/latest-v19.x/api/stream.html#object-mode](https://nodejs.org/docs/latest-v19.x/api/stream.html#object-mode))  The `writableObjectMode` flag of a stream can be used to determine whether a stream is operating in object mode.  (See [https://nodejs.org/docs/latest-v19.x/api/stream.html#writablewritableobjectmode](https://nodejs.org/docs/latest-v19.x/api/stream.html#writablewritableobjectmode))  This has been part of the Node API since [version 12](https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_writable_writableobjectmode).

This change simply alters Morgan so that it does *not* concatenate the return value of a format function with a new-line as long as (1) the return value is an object, and (2) the underlying stream's `writableObjectMode` flag is truthy.  It also adds two unit tests:  the first verifies that an object will be passed to the stream without modification if it is in object mode; the second verifies that an object will be converted to a string if the stream is not in object mode (as is the current behavior).  I did not make any changes to the README, but I would be willing to if you were intending to accept this request.

As an example of why this is useful, the following code snippet shows how this change allows Morgan to work in conjunction with [Winston](https://github.com/winstonjs/winston) to create an access log in JSON format.  By providing the data as an object instead of a string, the individual pieces of data can be easily utilized by the underlying logger.
```js
app.use(morgan(
  function (tokens, req, res) {
    return {
      method: tokens.method(req, res),
      url: tokens.url(req, res),
      status: Number.parseFloat(tokens.status(req, res)),
    }
  },
  {
    stream: {
      writableObjectMode: true,
      write(message: any) { logger.log({ level: 'http', ...message }) }
    }
  }
))
```

This change does alter existing behavior.  However, the `objectMode` option for streams is false by default.  (See [https://nodejs.org/docs/latest-v19.x/api/stream.html#stream_new_stream_writable_options](https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_new_stream_writable_options))  More specifically, it is false in `process.stdout`, in streams created by `fs.createWriteStream`, and in streams created by `require('rotating-file-stream').createStream` -- which are the three types of streams mentioned in the README.  Furthermore, using built-in formats and format strings always results in a string value.  Therefore, the only way this could be a breaking change is if a user (1) used a custom format function that returned an object, (2) used an underlying stream that had `writableObjectMode` set to true, and (3) was relying on Morgan to convert the object to a string.  This seems highly unlikely, and, even if it did happen, could be fixed by merely updating the format function to convert its return value to string.

Note that there is currently a work-around for this issue, which is to make the format function return JSON, and the underlying stream parse the JSON, as described in [https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-winston-and-morgan-to-log-node-js-applications/#logging-in-an-express-application-using-winston-and-morgan](https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-winston-and-morgan-to-log-node-js-applications/#logging-in-an-express-application-using-winston-and-morgan).  This works, but is inefficient and inelegant.