### PR TITLE
Fix: CVE-2017-20165 from debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "expressjs/morgan",
   "dependencies": {
     "basic-auth": "~2.0.1",
-    "debug": "2.6.9",
+    "debug": "3.1.0",
     "depd": "~2.0.0",
     "on-finished": "~2.3.0",
     "on-headers": "~1.0.2"


### PR DESCRIPTION
A vulnerability (CVE-2017-20165) classified as problematic has been found in debug-js debug up to 3.0.x. Upgrading to version 3.1.0 is able to address this issue. 

This pull request is just updating debug to 3.1.0. Library tested following this edit, no behavioral change detected.

More details about this CVE here: [nvd.nist.gov/vuln/detail/CVE-2017-20165](https://nvd.nist.gov/vuln/detail/CVE-2017-20165)

