### PR TITLE
doc: add replace reference from CJS to EJS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install morgan
 <!-- eslint-disable no-unused-vars -->
 
 ```js
-var morgan = require('morgan')
+import morgan from "morgan";
 ```
 
 ### morgan(format, options)


### PR DESCRIPTION
To import this we have to use ```var morgan = require("morgan");``` which is outdated
we should use ``` import morgan from "morgan"; ``` 