### PR TITLE
A11y: support NO_COLOR environment variable in output

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,14 @@ var CLF_MONTH = [
 ]
 
 /**
+ * Whether to disable colored output in dev mode.
+ * Accessibility standard as per https://no-color.org/
+ * @private
+ */
+
+var NO_COLOR = !!process.env.NO_COLOR;
+
+/**
  * Default log buffer duration.
  * @private
  */
@@ -187,11 +195,12 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     : undefined
 
   // get status color
-  var color = status >= 500 ? 31 // red
-    : status >= 400 ? 33 // yellow
-      : status >= 300 ? 36 // cyan
-        : status >= 200 ? 32 // green
-          : 0 // no color
+  var color = NO_COLOR ? 0 // color disabled by environment variable
+    : status >= 500 ? 31 // red
+      : status >= 400 ? 33 // yellow
+        : status >= 300 ? 36 // cyan
+          : status >= 200 ? 32 // green
+            : 0 // no color
 
   // get colored function
   var fn = developmentFormatLine[color]

--- a/index.js
+++ b/index.js
@@ -41,14 +41,6 @@ var CLF_MONTH = [
 ]
 
 /**
- * Whether to disable colored output in dev mode.
- * Accessibility standard as per https://no-color.org/
- * @private
- */
-
-var NO_COLOR = !!process.env.NO_COLOR;
-
-/**
  * Default log buffer duration.
  * @private
  */
@@ -195,7 +187,7 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     : undefined
 
   // get status color
-  var color = NO_COLOR ? 0 // color disabled by environment variable
+  var color = process.env.NO_COLOR ? 0 // color disabled by environment variable
     : status >= 500 ? 31 // red
       : status >= 400 ? 33 // yellow
         : status >= 300 ? 36 // cyan

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1312,6 +1312,41 @@ describe('morgan()', function () {
           .expect(500, cb)
       })
 
+      describe('NO_COLOR environment variable', function () {
+        var noColorInitial = process.env.NO_COLOR
+
+        beforeEach(() => {
+          console.log('No color')
+          process.env.NO_COLOR = '1'
+        })
+
+        afterEach(() => {
+          process.env.NO_COLOR = noColorInitial
+        })
+
+        it('should color if NO_COLOR environment variable is set', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(line.substr(0, 36), '_color_0_GET / _color_0_500_color_0_')
+            assert.strictEqual(line.substr(-9), '_color_0_')
+            done()
+          })
+
+          var stream = createColorLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 500
+            next()
+          })
+
+          request(server)
+            .get('/')
+            .expect(500, cb)
+        })
+      })
+
       describe('with "immediate: true" option', function () {
         it('should not have color or response values', function (done) {
           var cb = after(2, function (err, res, line) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

Resolves #302

This is a quick fix, rather than a major change to the system Morgan uses for styled console output. In an ideal world, using `NO_COLOR` would disable all styling of output, which would remove the presence of control characters in things like CI logs. Currently, this PR just sets the color to `0` if `NO_COLOR` is set in `process.env`, which is acceptable for accessibility.

As a side note: I'm not used to writing code for such old versions of Node, so apologies if I made any mistakes that break that compatibility. I tried testing using Node 0.8.28, but was unable to get `npm i` to work correctly. Let me know if I broke anything and I'll do my best to fix it up :)

- [x] Implementation
- [x] Test suite passes with 100% coverage
- [x] Linting passes with no errors or warnings

I accept the certificate of origin, and am happy for my contribution to use the project's MIT software license.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
