### PR TITLE
fix: respect NO_COLOR environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,12 +186,13 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     ? res.statusCode
     : undefined
 
-  // get status color
-  var color = status >= 500 ? 31 // red
-    : status >= 400 ? 33 // yellow
-      : status >= 300 ? 36 // cyan
-        : status >= 200 ? 32 // green
-          : 0 // no color
+  // get status color (disabled if NO_COLOR is set)
+  var color = process.env.NO_COLOR ? 0
+    : status >= 500 ? 31 // red
+      : status >= 400 ? 33 // yellow
+        : status >= 300 ? 36 // cyan
+          : status >= 200 ? 32 // green
+            : 0 // no color
 
   // get colored function
   var fn = developmentFormatLine[color]


### PR DESCRIPTION
## Bug\n\nmorgan dev format does not respect NO_COLOR=1 environment variable (morgan#302)\n\n## Fix\nCheck process.env.NO_COLOR and disable colored output when set.\n\nThis complies with no-color.org standard for accessibility.