### PR TITLE
fix: respect NO_COLOR environment variable in dev format

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,18 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     ? res.statusCode
     : undefined
 
+  // respect NO_COLOR environment variable (see https://no-color.org)
+  if ('NO_COLOR' in process.env) {
+    var fn = developmentFormatLine.nocolor
+
+    if (!fn) {
+      fn = developmentFormatLine.nocolor = compile(
+        ':method :url :status :response-time ms - :res[content-length]')
+    }
+
+    return fn(tokens, req, res)
+  }
+
   // get status color
   var color = status >= 500 ? 31 // red
     : status >= 400 ? 33 // yellow
@@ -194,7 +206,7 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
           : 0 // no color
 
   // get colored function
-  var fn = developmentFormatLine[color]
+  fn = developmentFormatLine[color]
 
   if (!fn) {
     // compile

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1354,6 +1354,31 @@ describe('morgan()', function () {
       })
     })
 
+    describe('dev with NO_COLOR', function () {
+      it('should not use ANSI color codes', function (done) {
+        var cb = after(2, function (err, res, line) {
+          if (err) return done(err)
+          assert.strictEqual(line.indexOf('\x1b'), -1, 'should not contain ANSI escape codes')
+          assert.ok(/GET \/ 200/.test(line), 'should contain method, url, and status')
+          done()
+        })
+
+        var stream = createLineStream(function onLine (line) {
+          cb(null, null, line)
+        })
+
+        process.env.NO_COLOR = ''
+        var server = createServer('dev', { stream: stream })
+
+        request(server)
+          .get('/')
+          .expect(200, function (err, res) {
+            delete process.env.NO_COLOR
+            cb(err, res)
+          })
+      })
+    })
+
     describe('short', function () {
       it('should match expectations', function (done) {
         var cb = after(2, function (err, res, line) {


### PR DESCRIPTION
## Summary

The `dev` format now respects the `NO_COLOR` environment variable by omitting ANSI escape codes when it is set.

## Problem

The `dev` format uses ANSI color codes to colorize HTTP status codes (green for 2xx, cyan for 3xx, yellow for 4xx, red for 5xx). However, it does not respect the [`NO_COLOR`](https://no-color.org/) environment variable, which is the widely-accepted standard for disabling color output in terminal applications.

This causes accessibility issues for users with limited vision and problems in environments where ANSI escape codes are not supported or cause garbled output (CI logs, file redirection, etc.).

## Fix

When `NO_COLOR` is set in `process.env`, the `dev` format outputs plain text without any ANSI escape sequences:

```
GET / 200 2.341 ms - 13
```

Instead of:

```
\x1b[0mGET / \x1b[32m200\x1b[0m 2.341 ms - 13\x1b[0m
```

The no-color format is cached separately from colored formats, so there is no performance impact.

## Testing

Added a test that verifies the output contains no ANSI escape codes when `NO_COLOR` is set. All 83 tests pass. Lint clean.

Fixes #302