### PR TITLE
support NO_COLOR environment variable in dev format

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,20 +186,27 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     ? res.statusCode
     : undefined
 
-  // get status color
-  var color = status >= 500 ? 31 // red
-    : status >= 400 ? 33 // yellow
-      : status >= 300 ? 36 // cyan
-        : status >= 200 ? 32 // green
-          : 0 // no color
+  // get status color (respect NO_COLOR env var)
+  var noColor = 'NO_COLOR' in process.env
+  var color = noColor ? 0
+    : status >= 500 ? 31 // red
+      : status >= 400 ? 33 // yellow
+        : status >= 300 ? 36 // cyan
+          : status >= 200 ? 32 // green
+            : 0 // no color
 
   // get colored function
-  var fn = developmentFormatLine[color]
+  var fn = developmentFormatLine[noColor ? 'nocolor' : color]
 
   if (!fn) {
-    // compile
-    fn = developmentFormatLine[color] = compile('\x1b[0m:method :url \x1b[' +
-      color + 'm:status\x1b[0m :response-time ms - :res[content-length]\x1b[0m')
+    if (noColor) {
+      // compile without ANSI escape codes
+      fn = developmentFormatLine['nocolor'] = compile(':method :url :status :response-time ms - :res[content-length]')
+    } else {
+      // compile with color
+      fn = developmentFormatLine[color] = compile('\x1b[0m:method :url \x1b[' +
+        color + 'm:status\x1b[0m :response-time ms - :res[content-length]\x1b[0m')
+    }
   }
 
   return fn(tokens, req, res)

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1352,6 +1352,61 @@ describe('morgan()', function () {
             .expect(200, cb)
         })
       })
+
+      describe('with NO_COLOR env var', function () {
+        before(function () {
+          process.env.NO_COLOR = ''
+        })
+
+        after(function () {
+          delete process.env.NO_COLOR
+          // clear cached format functions
+          delete morgan.dev.nocolor
+        })
+
+        it('should not include ANSI escape codes', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.ok(line.indexOf('\x1b[') === -1, 'should not contain ANSI escape codes')
+            done()
+          })
+
+          var stream = createLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 200
+            next()
+          })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+
+        it('should still include status code and method', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.ok(line.indexOf('GET') !== -1, 'should contain method')
+            assert.ok(line.indexOf('200') !== -1, 'should contain status')
+            done()
+          })
+
+          var stream = createLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 200
+            next()
+          })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+      })
     })
 
     describe('short', function () {


### PR DESCRIPTION
The dev format now checks for the NO_COLOR environment variable
(https://no-color.org/) and omits ANSI escape codes when it is set.

When `NO_COLOR` is present in `process.env`, the dev format compiles a
plain-text format string without any `\x1b[` sequences and caches it
under a separate `'nocolor'` key so colored and uncolored output don't
interfere with each other.

Two new tests cover the behavior:
- output contains no ANSI escape codes when `NO_COLOR` is set
- output still includes the HTTP method and status code

Fixes #302