### PR TITLE
feat: respect NO_COLOR environment variable in dev format

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,17 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     ? res.statusCode
     : undefined
 
+  // respect NO_COLOR environment variable (https://no-color.org/)
+  if (process.env.NO_COLOR !== undefined) {
+    var fn = developmentFormatLine._nocolor
+
+    if (!fn) {
+      fn = developmentFormatLine._nocolor = compile(':method :url :status :response-time ms - :res[content-length]')
+    }
+
+    return fn(tokens, req, res)
+  }
+
   // get status color
   var color = status >= 500 ? 31 // red
     : status >= 400 ? 33 // yellow


### PR DESCRIPTION
## Problem

The `morgan('dev')` format always outputs ANSI color codes, with no way to disable them. The `NO_COLOR` environment variable (https://no-color.org/) is the widely-accepted standard for disabling colour in terminal applications, but morgan does not check for it.

## Changes

Added a `NO_COLOR` environment variable check at the start of the `developmentFormatLine` function. When `process.env.NO_COLOR` is set, the dev format outputs plain text without ANSI color codes, matching the format of the `tiny` or `short` format but preserving the token structure of `dev`.

## Why

Colorful outputs can cause significant accessibility issues for people with limited vision. The `NO_COLOR` standard is supported by many CLI tools and frameworks, and this change brings morgan in line with the ecosystem.

Fixes #302