### PR TITLE
Release 1.11.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
-unreleased
+1.11.0 / 2026-06-02
 ===================
   * add `:pid` token
+
+  Security Fix:
+  * Escape control characters in `:remote-user` token to prevent log injection 
+    * Fixes [CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078) [GHSA-4vj7-5mj6-jm8m](https://github.com/expressjs/morgan/security/advisories/GHSA-4vj7-5mj6-jm8m)
 
 1.10.1 / 2025-07-17
 ===================

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "morgan",
   "description": "HTTP request logger middleware for node.js",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -668,9 +668,10 @@ describe('morgan()', function () {
           cb(null, null, line)
         })
 
+        // 'evil\nuser:x' (literal backslash) in Base64
         request(createServer(':remote-user', { stream: stream }))
           .get('/')
-          .set('Authorization', 'Basic ' + Buffer.from('evil\\nuser:x').toString('base64'))
+          .set('Authorization', 'Basic ZXZpbFxudXNlcjp4')
           .expect(200, cb)
       })
 


### PR DESCRIPTION
1.11.0 / 2026-06-02
===================
  * add `:pid` token

  Security Fix:
  * Escape control characters in `:remote-user` token to prevent log injection 
    * Fixes [CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078) [GHSA-4vj7-5mj6-jm8m](https://github.com/expressjs/morgan/security/advisories/GHSA-4vj7-5mj6-jm8m)
