### PR TITLE
fix: respect NO_COLOR environment variable in dev format

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,13 +219,19 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
         : status >= 200 ? 32 // green
           : 0 // no color
 
+  // respect NO_COLOR environment variable (https://no-color.org/)
+  var noColor = 'NO_COLOR' in process.env
+
   // get colored function
-  var fn = developmentFormatLine[color]
+  var key = noColor ? 'plain' : color
+  var fn = developmentFormatLine[key]
 
   if (!fn) {
     // compile
-    fn = developmentFormatLine[color] = compile('\x1b[0m:method :url \x1b[' +
-      color + 'm:status\x1b[0m :response-time ms - :res[content-length]\x1b[0m')
+    fn = developmentFormatLine[key] = noColor
+      ? compile(':method :url :status :response-time ms - :res[content-length]')
+      : compile('\x1b[0m:method :url \x1b[' +
+        color + 'm:status\x1b[0m :response-time ms - :res[content-length]\x1b[0m')
   }
 
   return fn(tokens, req, res)

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
           : 0 // no color
 
   // respect NO_COLOR environment variable (https://no-color.org/)
-  var noColor = 'NO_COLOR' in process.env
+  var noColor = Boolean(process.env.NO_COLOR)
 
   // get colored function
   var key = noColor ? 'plain' : color

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1333,6 +1333,20 @@ describe('morgan()', function () {
     })
 
     describe('dev', function () {
+      var noColor = process.env.NO_COLOR
+
+      beforeEach(function () {
+        delete process.env.NO_COLOR
+      })
+
+      afterEach(function () {
+        if (noColor === undefined) {
+          delete process.env.NO_COLOR
+        } else {
+          process.env.NO_COLOR = noColor
+        }
+      })
+
       it('should not color 1xx', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
@@ -1476,16 +1490,12 @@ describe('morgan()', function () {
       })
 
       describe('with NO_COLOR environment variable', function () {
-        afterEach(function () {
-          delete process.env.NO_COLOR
-        })
-
         it('should omit ANSI color codes when NO_COLOR is set', function (done) {
           process.env.NO_COLOR = '1'
 
           var cb = after(2, function (err, res, line) {
             if (err) return done(err)
-            assert.strictEqual(/\x1b\[/.test(line), false, 'expected no ANSI codes')
+            assert.strictEqual(line.indexOf('\x1b['), -1, 'expected no ANSI codes')
             done()
           })
 
@@ -1505,7 +1515,7 @@ describe('morgan()', function () {
 
           var cb = after(2, function (err, res, line) {
             if (err) return done(err)
-            assert.strictEqual(/\x1b\[/.test(line), false, 'expected no ANSI codes')
+            assert.strictEqual(line.indexOf('\x1b['), -1, 'expected no ANSI codes')
             done()
           })
 
@@ -1521,6 +1531,26 @@ describe('morgan()', function () {
           request(server)
             .get('/')
             .expect(500, cb)
+        })
+
+        it('should preserve color when NO_COLOR is empty', function (done) {
+          process.env.NO_COLOR = ''
+
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_32_200_color_0_')
+            done()
+          })
+
+          var stream = createColorLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
         })
       })
     })

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1474,6 +1474,55 @@ describe('morgan()', function () {
             .expect(200, cb)
         })
       })
+
+      describe('with NO_COLOR environment variable', function () {
+        afterEach(function () {
+          delete process.env.NO_COLOR
+        })
+
+        it('should omit ANSI color codes when NO_COLOR is set', function (done) {
+          process.env.NO_COLOR = '1'
+
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(/\x1b\[/.test(line), false, 'expected no ANSI codes')
+            done()
+          })
+
+          var stream = createLineStream(function (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+
+        it('should omit ANSI color codes for 5xx when NO_COLOR is set', function (done) {
+          process.env.NO_COLOR = '1'
+
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(/\x1b\[/.test(line), false, 'expected no ANSI codes')
+            done()
+          })
+
+          var stream = createLineStream(function (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 500
+            next()
+          })
+
+          request(server)
+            .get('/')
+            .expect(500, cb)
+        })
+      })
     })
 
     describe('short', function () {


### PR DESCRIPTION
## Summary

The `dev` format currently emits ANSI color escape codes unconditionally. This change follows the [`NO_COLOR`](https://no-color.org/) convention: color is disabled when `NO_COLOR` is present and non-empty, while an empty value preserves the existing behavior.

## Changes

**`index.js`**

- Check whether `NO_COLOR` has a non-empty value before compiling the dev format.
- Cache a plain format without ANSI escape codes when color is disabled.
- Preserve the current colored output when `NO_COLOR` is absent or empty.

**`test/morgan.js`**

- Cover color-free 2xx and 5xx output with `NO_COLOR=1`.
- Cover the convention's empty-value behavior.
- Isolate the dev-format tests from an inherited `NO_COLOR` shell value and restore the original environment after each test.

## Testing

- `npm test` — 91 passing
- `npm run lint`
- `git diff --check`

Closes #302
