### PR TITLE
fix: protect method names from token registration collisions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ module.exports.compile = compile
 module.exports.format = format
 module.exports.token = token
 
+// Protect method names from being overwritten by token registrations
+Object.defineProperties(module.exports, {
+  compile: { writable: false, configurable: false },
+  format: { writable: false, configurable: false },
+  token: { writable: false, configurable: false }
+})
+
 /**
  * Module dependencies.
  * @private


### PR DESCRIPTION
## Problem

Calling `morgan.token('token', fn)` overwrites the `morgan.token()` method itself, breaking all subsequent token registrations. This is because `morgan` serves as both the module export (with methods `token`, `format`, `compile`) and the token registry.

Example:
```js
var logger = require('morgan');
logger.token('token', function (req, res) { return 'value' });
// morgan.token is now the custom function, not the registration method
logger.token('uuid', function (req, res) { return 'uuid' }); // TypeError: tokens.uuid is not a function
```

## Fix

Make the `token`, `format`, and `compile` methods non-writable using `Object.defineProperties`. This prevents user token registrations from overwriting the module API while maintaining full backward compatibility.

## Test plan

- [x] Existing built-in tokens work correctly
- [x] Custom token registration works
- [x] Compiled format functions resolve tokens correctly
- [x] Middleware logs correctly
- [x] Registering reserved names (token, format, compile) now throws instead of silently breaking