### PR TITLE
fix(dev): respect NO_COLOR for colored status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ token will be colored green for success codes, red for server error codes,
 yellow for client error codes, cyan for redirection codes, and uncolored
 for information codes.
 
+When the `NO_COLOR` environment variable is set (to any non-empty value),
+color is disabled per [no-color.org](https://no-color.org/).
+
 ```
 :method :url :status :response-time ms - :res[content-length]
 # will output

--- a/index.js
+++ b/index.js
@@ -212,6 +212,15 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     ? res.statusCode
     : undefined
 
+  // Respect NO_COLOR (https://no-color.org/)
+  if (process.env.NO_COLOR) {
+    var plain = developmentFormatLine.noColor
+    if (!plain) {
+      plain = developmentFormatLine.noColor = compile(':method :url :status :response-time ms - :res[content-length]')
+    }
+    return plain(tokens, req, res)
+  }
+
   // get status color
   var color = status >= 500 ? 31 // red
     : status >= 400 ? 33 // yellow

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1333,6 +1333,21 @@ describe('morgan()', function () {
     })
 
     describe('dev', function () {
+      var previousNoColor
+
+      before(function () {
+        previousNoColor = process.env.NO_COLOR
+        delete process.env.NO_COLOR
+      })
+
+      after(function () {
+        if (previousNoColor === undefined) {
+          delete process.env.NO_COLOR
+        } else {
+          process.env.NO_COLOR = previousNoColor
+        }
+      })
+
       it('should not color 1xx', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
@@ -1467,6 +1482,46 @@ describe('morgan()', function () {
           var server = createServer('dev', {
             immediate: true,
             stream: stream
+          })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+      })
+
+      describe('with NO_COLOR set', function () {
+        var previousNoColor
+
+        before(function () {
+          previousNoColor = process.env.NO_COLOR
+          process.env.NO_COLOR = '1'
+        })
+
+        after(function () {
+          if (previousNoColor === undefined) {
+            delete process.env.NO_COLOR
+          } else {
+            process.env.NO_COLOR = previousNoColor
+          }
+        })
+
+        it('should not emit ANSI color codes', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(/\x1b\[/.test(line), false)
+            var masked = line.replace(/\d+\.\d{3} ms/, '_timer_')
+            assert.strictEqual(masked, 'GET / 200 _timer_ - -')
+            done()
+          })
+
+          var stream = createLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 200
+            next()
           })
 
           request(server)


### PR DESCRIPTION
## Summary
- Disable ANSI colors in the `dev` format when `NO_COLOR` is set (https://no-color.org/)
- Document the behavior in the README
- Add a regression test for `NO_COLOR=1`

Closes #302

## Test plan
- [x] `npm test` (Node 20): 89 passing
- [x] Confirm `morgan('dev')` still colors status codes when `NO_COLOR` is unset
- [x] Confirm `morgan('dev')` emits no ANSI sequences when `NO_COLOR=1`