### PR TITLE
fix(dev): respect NO_COLOR environment variable in dev format

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,11 +213,12 @@ morgan.format('dev', function developmentFormatLine (tokens, req, res) {
     : undefined
 
   // get status color
-  var color = status >= 500 ? 31 // red
-    : status >= 400 ? 33 // yellow
-      : status >= 300 ? 36 // cyan
-        : status >= 200 ? 32 // green
-          : 0 // no color
+  var color = process.env.NO_COLOR ? 0
+    : status >= 500 ? 31 // red
+      : status >= 400 ? 33 // yellow
+        : status >= 300 ? 36 // cyan
+          : status >= 200 ? 32 // green
+            : 0 // no color
 
   // get colored function
   var fn = developmentFormatLine[color]

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1474,6 +1474,39 @@ describe('morgan()', function () {
             .expect(200, cb)
         })
       })
+
+      describe('when NO_COLOR is set', function () {
+        var oldNoColor
+
+        before(function () {
+          oldNoColor = process.env.NO_COLOR
+          process.env.NO_COLOR = '1'
+        })
+
+        after(function () {
+          process.env.NO_COLOR = oldNoColor
+        })
+
+        it('should not have color', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(line, '_color_0_GET / _color_0_200_color_0_ - ms - -_color_0_')
+            done()
+          })
+
+          var stream = createColorLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', {
+            stream: stream
+          })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+      })
     })
 
     describe('short', function () {


### PR DESCRIPTION
## Summary
Disable ANSI color output in `morgan('dev')` format when `process.env.NO_COLOR` is set, adhering to the [NO_COLOR](https://no-color.org/) standard.

## Motivation
CLI tools and log aggregators following the NO_COLOR standard require color-free output for accessibility and automated parsing. Closes #302.

## Implementation
Check `process.env.NO_COLOR` in the `dev` format formatter before resolving ANSI color codes.

## Testing
Added unit test verifying `NO_COLOR=1` produces uncolored dev format log output in `test/morgan.js`.
