### PR TITLE
fix(token): throw on reserved token names instead of silently corrupting morgan

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ morgan.token('type', function (req, res) { return req.headers['content-type'] })
 Calling `morgan.token()` using the same name as an existing token will overwrite that
 token definition.
 
+The names `token`, `format`, and `compile` are reserved by morgan itself and cannot be
+used as custom token names. Attempting to register a token with one of these names will
+throw a `TypeError`.
+
 The token function is expected to be called with the arguments `req` and `res`, representing
 the HTTP request and HTTP response. Additionally, the token can accept further arguments of
 it's choosing to customize behavior.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ module.exports.compile = compile
 module.exports.format = format
 module.exports.token = token
 
+var RESERVED_TOKEN_NAMES = ['compile', 'format', 'token']
+
 /**
  * Module dependencies.
  * @private
@@ -573,6 +575,10 @@ function recordStartTime () {
  */
 
 function token (name, fn) {
+  if (RESERVED_TOKEN_NAMES.indexOf(name) !== -1) {
+    throw new TypeError('cannot use reserved name "' + name + '" for a token; choose a different name')
+  }
+
   morgan[name] = fn
   return this
 }

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1713,6 +1713,35 @@ describe('morgan.compile(format)', function () {
   })
 })
 
+describe('morgan.token(name, fn)', function () {
+  describe('arguments', function () {
+    describe('name', function () {
+      it('should reject reserved names', function () {
+        assert.throws(morgan.token.bind(morgan, 'token', function () {}), /reserved name/)
+        assert.throws(morgan.token.bind(morgan, 'format', function () {}), /reserved name/)
+        assert.throws(morgan.token.bind(morgan, 'compile', function () {}), /reserved name/)
+      })
+
+      it('should not corrupt morgan.token after rejecting a reserved name', function () {
+        assert.throws(morgan.token.bind(morgan, 'token', function () {}), /reserved name/)
+
+        // morgan.token itself must still be a working function
+        assert.strictEqual(typeof morgan.token, 'function')
+
+        // and registering a normal token afterwards must still work
+        morgan.token('my-custom-token', function () { return 'custom-value' })
+        assert.strictEqual(typeof morgan['my-custom-token'], 'function')
+      })
+
+      it('should allow non-reserved names', function () {
+        var fn = function () { return 'value' }
+        morgan.token('some-other-token', fn)
+        assert.strictEqual(morgan['some-other-token'], fn)
+      })
+    })
+  })
+})
+
 function after (count, callback) {
   var args = new Array(3)
   var i = 0


### PR DESCRIPTION
Fixes #265

Calling `morgan.token('token', fn)` (or 'format'/'compile') silently
overwrote morgan's own internal functions, since `token()` just does
`morgan[name] = fn`. This meant registering a token named "token" would
destroy `morgan.token` itself, causing every subsequent `.token()` call
to fail with an unrelated TypeError, with no indication of the real cause.

This PR:
- Adds a check in `token()` that throws a clear TypeError when a
  reserved name (`token`, `format`, `compile`) is used
- Adds regression tests, including one that verifies `morgan.token`
  remains a valid function after a rejected registration (the exact
  failure mode from the original bug report)
- Documents the reserved names in the Readme, as requested by
  @dougwilson in the original issue thread

All 91 existing tests still pass.