### PR TITLE
Respect NO_COLOR environment variable in the dev format

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ for information codes.
 GET /dev 200 0.224 ms - 2
 ```
 
+Set the `NO_COLOR` environment variable to a non-empty value to disable the
+colored output (see [no-color.org](https://no-color.org/)). The same fields are
+then printed without any ANSI escape sequences.
+
 ##### short
 
 Shorter than default, also including response time.

--- a/index.js
+++ b/index.js
@@ -207,6 +207,15 @@ morgan.format('tiny', ':method :url :status :res[content-length] - :response-tim
  */
 
 morgan.format('dev', function developmentFormatLine (tokens, req, res) {
+  // NO_COLOR (https://no-color.org/): when present and not an empty
+  // string, regardless of its value, ANSI color codes must not be added
+  if (process.env.NO_COLOR) {
+    var plainFn = developmentFormatLine.plain || (developmentFormatLine.plain =
+      compile(':method :url :status :response-time ms - :res[content-length]'))
+
+    return plainFn(tokens, req, res)
+  }
+
   // get the status code if response written
   var status = headersSent(res)
     ? res.statusCode

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1474,6 +1474,38 @@ describe('morgan()', function () {
             .expect(200, cb)
         })
       })
+
+      describe('with NO_COLOR environment variable set', function () {
+        beforeEach(function () {
+          process.env.NO_COLOR = '1'
+        })
+
+        afterEach(function () {
+          delete process.env.NO_COLOR
+        })
+
+        it('should not emit any ANSI escape codes', function (done) {
+          var cb = after(2, function (err, res, line) {
+            if (err) return done(err)
+            assert.strictEqual(line.indexOf('\x1b'), -1)
+            assert.ok(/^GET \/ 200 \d+\.\d{3} ms - -$/.test(line), 'unexpected line: ' + line)
+            done()
+          })
+
+          var stream = createLineStream(function onLine (line) {
+            cb(null, null, line)
+          })
+
+          var server = createServer('dev', { stream: stream }, function (req, res, next) {
+            res.statusCode = 200
+            next()
+          })
+
+          request(server)
+            .get('/')
+            .expect(200, cb)
+        })
+      })
     })
 
     describe('short', function () {


### PR DESCRIPTION
## Summary

Fixes #302.

`morgan('dev')` always emits ANSI color escape codes with no way to turn them off, even though [`NO_COLOR`](https://no-color.org/) is the widely adopted convention for this, and colored escape codes mixed into logs can be a real accessibility problem for some terminal/screen-reader setups.

## Fix

When `NO_COLOR` is set to a non-empty value, `dev` compiles and uses a plain, escape-code-free variant of the format line instead of the colored one (`:method :url :status :response-time ms - :res[content-length]`, i.e. the same fields the colored line already prints, just without the `\x1b[...]` codes). It's cached the same way the colored variants already are, so there's no extra compile cost per request.

No other formats are affected — `dev` is the only built-in format that emits color.

## Test plan

- Added a test under the existing `dev` describe block: with `NO_COLOR=1` set, asserts the logged line contains no `\x1b` escape character and matches the expected plain fields.
- Verified the regression: reverting the source change turns the new test from passing into failing (`indexOf('\x1b')` returns `0` instead of `-1`, i.e. an escape code is present at the start of the line).
- Full suite passes: `npx mocha --check-leaks --reporter spec` — 89 passing.
- `npm run lint` (eslint) passes on the changed files.