### PR TITLE
ci: use latest patch per Node.js major, add 23-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         name:
         - Node.js 0.8
@@ -41,6 +42,10 @@ jobs:
         - Node.js 20.x
         - Node.js 21.x
         - Node.js 22.x
+        - Node.js 23.x
+        - Node.js 24.x
+        - Node.js 25.x
+        - Node.js 26.x
 
         include:
         - name: Node.js 0.8
@@ -69,71 +74,83 @@ jobs:
           npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
 
         - name: Node.js 4.x
-          node-version: "4.9"
+          node-version: "4"
           npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
 
         - name: Node.js 5.x
-          node-version: "5.12"
+          node-version: "5"
           npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
 
         - name: Node.js 6.x
-          node-version: "6.17"
+          node-version: "6"
           npm-i: mocha@6.2.2 nyc@14.1.1
 
         - name: Node.js 7.x
-          node-version: "7.10"
+          node-version: "7"
           npm-i: mocha@6.2.2 nyc@14.1.1
 
         - name: Node.js 8.x
-          node-version: "8.17"
+          node-version: "8"
           npm-i: mocha@7.1.2 nyc@14.1.1
 
         - name: Node.js 9.x
-          node-version: "9.11"
+          node-version: "9"
           npm-i: mocha@7.1.2 nyc@14.1.1
 
         - name: Node.js 10.x
-          node-version: "10.24"
+          node-version: "10"
           npm-i: mocha@8.4.0
 
         - name: Node.js 11.x
-          node-version: "11.15"
+          node-version: "11"
           npm-i: mocha@8.4.0
 
         - name: Node.js 12.x
-          node-version: "12.22"
+          node-version: "12"
           npm-i: mocha@9.2.2
 
         - name: Node.js 13.x
-          node-version: "13.14"
+          node-version: "13"
           npm-i: mocha@9.2.2
 
         - name: Node.js 14.x
-          node-version: "14.21"
+          node-version: "14"
 
         - name: Node.js 15.x
-          node-version: "15.14"
+          node-version: "15"
 
         - name: Node.js 16.x
-          node-version: "16.20"
+          node-version: "16"
 
         - name: Node.js 17.x
-          node-version: "17.9"
+          node-version: "17"
 
         - name: Node.js 18.x
-          node-version: "18.18"
+          node-version: "18"
 
         - name: Node.js 19.x
-          node-version: "19.9"
+          node-version: "19"
 
         - name: Node.js 20.x
-          node-version: "20.9"
+          node-version: "20"
 
         - name: Node.js 21.x
-          node-version: "21.1"
+          node-version: "21"
 
         - name: Node.js 22.x
-          node-version: "22.0"
+          node-version: "22"
+
+        - name: Node.js 23.x
+          node-version: "23"
+
+        - name: Node.js 24.x
+          node-version: "24"
+
+        - name: Node.js 25.x
+          node-version: "25"
+
+        - name: Node.js 26.x
+          node-version: "26"
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
### Main Changes

- node-version as bare major for Node.js >= 4 so nvm resolves the latest patch
- add Node.js 23.x, 24.x, 25.x and 26.x to the matrix
- set fail-fast: false so one failing version does not cancel the rest
