### PR TITLE
feat: pass objects through to streams in objectMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ morgan('combined', {
 
 Output stream for writing log lines, defaults to `process.stdout`.
 
+If the stream is in object mode (`stream.writableObjectMode` is `true`) and the
+format function returns an object, the object is written to the stream as-is,
+without a trailing newline. This allows passing structured log entries to
+loggers that accept objects:
+
+<!-- eslint-disable no-undef -->
+
+```js
+morgan(function (tokens, req, res) {
+  return {
+    method: tokens.method(req, res),
+    url: tokens.url(req, res),
+    status: Number(tokens.status(req, res))
+  }
+}, {
+  stream: {
+    writableObjectMode: true,
+    write: function (entry) {
+      // entry is the object returned by the format function
+    }
+  }
+})
+```
+
 #### Predefined Formats
 
 There are various pre-defined formats provided:

--- a/index.js
+++ b/index.js
@@ -153,7 +153,12 @@ function morgan (format, options) {
       }
 
       debug('log request')
-      stream.write(line + '\n')
+      if (stream.writableObjectMode && typeof line == 'object') {
+        stream.write(line)
+      }
+      else {
+        stream.write(line + '\n')
+      }
     };
 
     if (immediate) {

--- a/index.js
+++ b/index.js
@@ -153,10 +153,9 @@ function morgan (format, options) {
       }
 
       debug('log request')
-      if (stream.writableObjectMode && typeof line == 'object') {
+      if (stream.writableObjectMode && typeof line === 'object') {
         stream.write(line)
-      }
-      else {
+      } else {
         stream.write(line + '\n')
       }
     };

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1215,6 +1215,55 @@ describe('morgan()', function () {
           .get('/')
           .expect(200, done)
       })
+
+      it('should allow objects to pass-through for streams in object mode', function (done) {
+        var cb = after(2, function (err, res, line) {
+          if (err) return done(err)
+          assert.deepEqual(line, { method: 'GET', url: '/', statusCode: 200 })
+          done()
+        })
+
+        var stream = {
+          writableObjectMode: true,
+          write (obj) { cb(null, null, obj) }
+        }
+
+        function format (tokens, req, res) {
+          return {
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode
+          }
+        }
+
+        request(createServer(format, { stream: stream }))
+          .get('/')
+          .expect(200, cb)
+      })
+
+      it('should convert objects to string for streams not in object mode', function (done) {
+        var cb = after(2, function (err, res, line) {
+          if (err) return done(err)
+          assert.strictEqual(line, '[object Object]')
+          done()
+        })
+
+        var stream = createLineStream(function (line) {
+          cb(null, null, line)
+        })
+
+        function format (tokens, req, res) {
+          return {
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode
+          }
+        }
+
+        request(createServer(format, { stream: stream }))
+          .get('/')
+          .expect(200, cb)
+      })
     })
 
     describe('a string', function () {

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1225,7 +1225,7 @@ describe('morgan()', function () {
 
         var stream = {
           writableObjectMode: true,
-          write (obj) { cb(null, null, obj) }
+          write: function (obj) { cb(null, null, obj) }
         }
 
         function format (tokens, req, res) {


### PR DESCRIPTION
Supersedes #272 (rebased onto master; original commit and authorship preserved).

When the output stream has `writableObjectMode: true` and the format function returns an object, the object is written to the stream as-is instead of being coerced to a string with a trailing newline. Useful for winston-style loggers that consume structured entries.

Follow-up commits address the review gaps: lint, ES5 syntax in the test for Node < 4, README note.