### PR TITLE
Release: 1.12.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,19 +1,25 @@
-1.11.0 / 2026-06-02
-===================
+1.12.0
+======
+  * Security fix for [CVE-2026-15603](https://www.cve.org/CVERecord?id=CVE-2026-15603)([GHSA-jxfw-x594-9x9m](https://github.com/expressjs/morgan/security/advisories/GHSA-jxfw-x594-9x9m))
+  * Allow format functions to return objects for streams in `objectMode`
+  * Respect the `NO_COLOR` environment variable in the `dev` format
+
+1.11.0
+======
   * add `:pid` token
 
   Security Fix:
   * Escape control characters in `:remote-user` token to prevent log injection 
     * Fixes [CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078) [GHSA-4vj7-5mj6-jm8m](https://github.com/expressjs/morgan/security/advisories/GHSA-4vj7-5mj6-jm8m)
 
-1.10.1 / 2025-07-17
-===================
+1.10.1
+======
 
   * deps: on-headers@~1.1.0
     - Fix [CVE-2025-7339](https://www.cve.org/CVERecord?id=CVE-2025-7339) ([GHSA-76c9-3jph-rj3q](https://github.com/expressjs/on-headers/security/advisories/GHSA-76c9-3jph-rj3q))
 
-1.10.0 / 2020-03-20
-===================
+1.10.0
+======
 
   * Add `:total-time` token
   * Fix trailing space in colored status code for `dev` format
@@ -25,15 +31,15 @@
   * deps: on-headers@~1.0.2
     - Fix `res.writeHead` patch missing return value
 
-1.9.1 / 2018-09-10
-==================
+1.9.1
+=====
 
   * Fix using special characters in format
   * deps: depd@~1.1.2
     - perf: remove argument reassignment
 
-1.9.0 / 2017-09-26
-==================
+1.9.0
+=====
 
   * Use `res.headersSent` when available
   * deps: basic-auth@~2.0.0
@@ -42,22 +48,22 @@
   * deps: depd@~1.1.1
     - Remove unnecessary `Buffer` loading
 
-1.8.2 / 2017-05-23
-==================
+1.8.2
+=====
 
   * deps: debug@2.6.8
     - Fix `DEBUG_MAX_ARRAY_LENGTH`
     - deps: ms@2.0.0
 
-1.8.1 / 2017-02-04
-==================
+1.8.1
+=====
 
   * deps: debug@2.6.1
     - Fix deprecation messages in WebStorm and other editors
     - Undeprecate `DEBUG_FD` set to `1` or `2`
 
-1.8.0 / 2017-02-04
-==================
+1.8.0
+=====
 
   * Fix sending unnecessary `undefined` argument to token functions
   * deps: basic-auth@~1.1.0
@@ -69,8 +75,8 @@
     - deps: ms@0.7.2
   * perf: enable strict mode in compiled functions
 
-1.7.0 / 2016-02-18
-==================
+1.7.0
+=====
 
   * Add `digits` argument to `response-time` token
   * deps: depd@~1.1.0
@@ -79,13 +85,13 @@
   * deps: on-headers@~1.0.1
     - perf: enable strict mode
 
-1.6.1 / 2015-07-03
-==================
+1.6.1
+=====
 
   * deps: basic-auth@~1.0.3
 
-1.6.0 / 2015-06-12
-==================
+1.6.0
+=====
 
   * Add `morgan.compile(format)` export
   * Do not color 1xx status codes in `dev` format
@@ -109,8 +115,8 @@
   * pref: remove an argument reassignment
   * pref: skip function call without `skip` option
 
-1.5.3 / 2015-05-10
-==================
+1.5.3
+=====
 
   * deps: basic-auth@~1.0.1
   * deps: debug@~2.2.0
@@ -119,21 +125,21 @@
   * deps: on-finished@~2.2.1
     - Fix `isFinished(req)` when data buffered
 
-1.5.2 / 2015-03-15
-==================
+1.5.2
+=====
 
   * deps: debug@~2.1.3
     - Fix high intensity foreground color for bold
     - deps: ms@0.7.0
 
-1.5.1 / 2014-12-31
-==================
+1.5.1
+=====
 
   * deps: debug@~2.1.1
   * deps: on-finished@~2.2.0
 
-1.5.0 / 2014-11-06
-==================
+1.5.0
+=====
 
   * Add multiple date formats
     - `clf` for the common log format
@@ -143,53 +149,53 @@
   * Fix date format in `common` and `combined` formats
   * Fix token arguments to accept values with `"`
 
-1.4.1 / 2014-10-22
-==================
+1.4.1
+=====
 
   * deps: on-finished@~2.1.1
     - Fix handling of pipelined requests
 
-1.4.0 / 2014-10-16
-==================
+1.4.0
+=====
 
   * Add `debug` messages
   * deps: depd@~1.0.0
 
-1.3.2 / 2014-09-27
-==================
+1.3.2
+=====
 
   * Fix `req.ip` integration when `immediate: false`
 
-1.3.1 / 2014-09-14
-==================
+1.3.1
+=====
 
   * Remove un-used `bytes` dependency
   * deps: depd@0.4.5
 
-1.3.0 / 2014-09-01
-==================
+1.3.0
+=====
 
   * Assert if `format` is not a function or string
 
-1.2.3 / 2014-08-16
-==================
+1.2.3
+=====
 
   * deps: on-finished@2.1.0
 
-1.2.2 / 2014-07-27
-==================
+1.2.2
+=====
 
   * deps: depd@0.4.4
     - Work-around v8 generating empty stack traces
 
-1.2.1 / 2014-07-26
-==================
+1.2.1
+=====
 
   * deps: depd@0.4.3
     - Fix exception when global `Error.stackTraceLimit` is too low
 
-1.2.0 / 2014-07-19
-==================
+1.2.0
+=====
 
   * Add `:remote-user` token
   * Add `combined` log format
@@ -199,13 +205,13 @@
   * Deprecate not providing a format
   * Remove non-standard grey color from `dev` format
 
-1.1.1 / 2014-05-20
-==================
+1.1.1
+=====
 
   * simplify method to get remote address
 
-1.1.0 / 2014-05-18
-==================
+1.1.0
+=====
 
   * "dev" format will use same tokens as other formats
   * `:response-time` token is now empty when immediate used
@@ -216,14 +222,14 @@
   * deps: bytes@1.0.0
     - add negative support
 
-1.0.1 / 2014-05-04
-==================
+1.0.1
+=====
 
   * Make buffer unique per morgan instance
   * deps: bytes@0.3.0
     * added terabyte support
 
-1.0.0 / 2014-02-08
-==================
+1.0.0
+=====
 
   * Initial release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "morgan",
   "description": "HTTP request logger middleware for node.js",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
### What's included in the `HISTORY.md`

```
1.12.0
======
  * Security fix for [CVE-2026-15603](https://www.cve.org/CVERecord?id=CVE-2026-15603)([GHSA-jxfw-x594-9x9m](https://github.com/expressjs/morgan/security/advisories/GHSA-jxfw-x594-9x9m))
  * Allow format functions to return objects for streams in `objectMode`
  * Respect the `NO_COLOR` environment variable in the `dev` format
```

## What's Changed
* fix: upgrade http:// to https:// in README by @hanu-14 in https://github.com/expressjs/morgan/pull/363
* build: bump github actions and dev dependencies by @sheplu in https://github.com/expressjs/morgan/pull/369
* chore(ci): npm-publish via reusable workflows by @sheplu in https://github.com/expressjs/morgan/pull/334
* docs: add ES modules import example by @aladi-debug in https://github.com/expressjs/morgan/pull/352
* docs: fix README lint errors by @UlisesGascon in https://github.com/expressjs/morgan/pull/373
* ci: use latest patch per Node.js major, add 23-26 by @UlisesGascon in https://github.com/expressjs/morgan/pull/374
* feat: pass objects through to streams in objectMode by @UlisesGascon in https://github.com/expressjs/morgan/pull/375
* feat: NO_COLOR env var removes color in dev format by @jonchurch in https://github.com/expressjs/morgan/pull/377

## New Contributors
* @hanu-14 made their first contribution in https://github.com/expressjs/morgan/pull/363
* @sheplu made their first contribution in https://github.com/expressjs/morgan/pull/369
* @aladi-debug made their first contribution in https://github.com/expressjs/morgan/pull/352

**Full Changelog**: https://github.com/expressjs/morgan/compare/1.11.0...master