### PR TITLE
docs: fix typos across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Morgan accepts these properties in the options object.
 
 ##### immediate
 
-Write log line on request instead of response. This means that a requests will
+Write log line on request instead of response. This means that requests will
 be logged even if the server crashes, _but data from the response (like the
 response code, content length, etc.) cannot be logged_.
 
@@ -212,7 +212,7 @@ token definition.
 
 The token function is expected to be called with the arguments `req` and `res`, representing
 the HTTP request and HTTP response. Additionally, the token can accept further arguments of
-it's choosing to customize behavior.
+its choosing to customize behavior.
 
 ##### :date[format]
 
@@ -238,7 +238,7 @@ The process ID of the Node.js process handling the request.
 
 ##### :referrer
 
-The Referrer header of the request. This will use the standard mis-spelled Referer header if exists, otherwise Referrer.
+The Referrer header of the request. This will use the standard mis-spelled Referer header if it exists, otherwise Referrer.
 
 ##### :remote-addr
 
@@ -284,7 +284,7 @@ include on the number, defaulting to `3`, which provides microsecond precision.
 
 ##### :url
 
-The URL of the request. This will use `req.originalUrl` if exists, otherwise `req.url`.
+The URL of the request. This will use `req.originalUrl` if it exists, otherwise `req.url`.
 
 ##### :user-agent
 
@@ -294,12 +294,12 @@ The contents of the User-Agent header of the request.
 
 Compile a format string into a `format` function for use by `morgan`. A format string
 is a string that represents a single log line and can utilize token syntax.
-Tokens are references by `:token-name`. If tokens accept arguments, they can
+Tokens are referenced by `:token-name`. If tokens accept arguments, they can
 be passed using `[]`, for example: `:token-name[pretty]` would pass the string
 `'pretty'` as an argument to the token `token-name`.
 
 The function returned from `morgan.compile` takes three arguments `tokens`, `req`, and
-`res`, where `tokens` is object with all defined tokens, `req` is the HTTP request and
+`res`, where `tokens` is an object with all defined tokens, `req` is the HTTP request and
 `res` is the HTTP response. The function will return a string that will be the log line,
 or `undefined` / `null` to skip logging.
 
@@ -310,7 +310,7 @@ advanced uses, this compile function is directly available.
 
 ### express/connect
 
-Sample app that will log all request in the Apache combined format to STDOUT
+Sample app that will log all requests in the Apache combined format to STDOUT
 
 ```js
 var express = require('express')
@@ -327,7 +327,7 @@ app.get('/', function (req, res) {
 
 ### vanilla http server
 
-Sample app that will log all request in the Apache combined format to STDOUT
+Sample app that will log all requests in the Apache combined format to STDOUT
 
 ```js
 var finalhandler = require('finalhandler')
@@ -445,7 +445,7 @@ Sample app that will use custom token formats. This adds an ID to all requests a
 ```js
 var express = require('express')
 var morgan = require('morgan')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 
 morgan.token('id', function getId (req) {
   return req.id

--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ morgan.token('total-time', function getTotalTimeToken (req, res, digits) {
   // time elapsed from request start
   var elapsed = process.hrtime(req._startAt)
 
-  // cover to milliseconds
+  // convert to milliseconds
   var ms = (elapsed[0] * 1e3) + (elapsed[1] * 1e-6)
 
   // return truncated value

--- a/test/morgan.js
+++ b/test/morgan.js
@@ -1525,7 +1525,7 @@ describe('morgan()', function () {
           .expect(300, cb)
       })
 
-      it('should color 4xx yelow', function (done) {
+      it('should color 4xx yellow', function (done) {
         var cb = after(2, function (err, res, line) {
           if (err) return done(err)
           assert.strictEqual(line.substr(0, 37), '_color_0_GET / _color_33_400_color_0_')


### PR DESCRIPTION
## Description

This PR improves documentation clarity and fixes minor typos across the repository:

1. **`README.md`**:
   - Updates deprecated `node-uuid` package reference to standard `uuid` in the custom token example.
   - Fixes grammar and typos in documentation:
     - "a requests" -> "requests" (immediate option description)
     - "of it's choosing" -> "of its choosing" (token description)
     - "if exists" -> "if it exists" (:referrer and :url tokens)
     - "Tokens are references by" -> "Tokens are referenced by"
     - "`tokens` is object" -> "`tokens` is an object"
     - "log all request" -> "log all requests" (examples header descriptions)

2. **`index.js`**:
   - Fixes typo in `total-time` token comment ("cover to milliseconds" -> "convert to milliseconds").

3. **`test/morgan.js`**:
   - Fixes test title typo ("should color 4xx yelow" -> "should color 4xx yellow").

## Test plan

- Ran `npm test` (all 99 tests passing across mocha test suites).
- Ran `npm run lint` (eslint passing with no errors or warnings).
